### PR TITLE
Remove exclusive language in documentation

### DIFF
--- a/docs/HistoricalNotes/2001-02-06-TypeNotationDebate.txt
+++ b/docs/HistoricalNotes/2001-02-06-TypeNotationDebate.txt
@@ -42,7 +42,7 @@ an experiment that failed. However, this syntactic construct has been
 around for 27 years and perhaps more; why do you consider it problematic
 (except for its cumbersome syntax)?" and read that response for me.  :)
 
-Now with this syntax, his example would be represented as:
+Now with this syntax, their example would be represented as:
 
 [ %10, bool (int, int) * ] *
 

--- a/docs/ProgrammersManual.rst
+++ b/docs/ProgrammersManual.rst
@@ -2526,7 +2526,7 @@ called *concept-based polymorphism*. This pattern emulates the interfaces and
 behaviors of templates using a very limited form of virtual dispatch for type
 erasure inside its implementation. You can find examples of this technique in
 the ``PassManager.h`` system, and there is a more detailed introduction to it
-by Sean Parent in several of his talks and papers:
+by Sean Parent in several of their talks and papers:
 
 #. `Inheritance Is The Base Class of Evil
    <http://channel9.msdn.com/Events/GoingNative/2013/Inheritance-Is-The-Base-Class-of-Evil>`_

--- a/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -241,7 +241,7 @@ public:
   /// \brief Return the DIE object for a given offset inside the
   /// unit's DIE vector.
   ///
-  /// The unit needs to have his DIEs extracted for this method to work.
+  /// The unit needs to have its DIEs extracted for this method to work.
   const DWARFDebugInfoEntryMinimal *getDIEForOffset(uint32_t Offset) const {
     assert(!DieArray.empty());
     auto it = std::lower_bound(

--- a/lib/Target/PowerPC/PPCLoopDataPrefetch.cpp
+++ b/lib/Target/PowerPC/PPCLoopDataPrefetch.cpp
@@ -135,7 +135,7 @@ bool PPCLoopDataPrefetch::runOnLoop(Loop *L) {
        I != IE; ++I) {
 
     // If the loop already has prefetches, then assume that the user knows
-    // what he or she is doing and don't add any more.
+    // what they are doing and don't add any more.
     for (BasicBlock::iterator J = (*I)->begin(), JE = (*I)->end();
          J != JE; ++J)
       if (CallInst *CI = dyn_cast<CallInst>(J))

--- a/utils/unittest/googletest/include/gtest/internal/gtest-internal.h
+++ b/utils/unittest/googletest/include/gtest/internal/gtest-internal.h
@@ -74,7 +74,7 @@
 // Google Test defines the testing::Message class to allow construction of
 // test messages via the << operator.  The idea is that anything
 // streamable to std::ostream can be streamed to a testing::Message.
-// This allows a user to use his own types in Google Test assertions by
+// This allows a user to use their own types in Google Test assertions by
 // overloading the << operator.
 //
 // util/gtl/stl_logging-inl.h overloads << for STL containers.  These

--- a/utils/unittest/googletest/src/gtest-test-part.cc
+++ b/utils/unittest/googletest/src/gtest-test-part.cc
@@ -37,7 +37,7 @@
 // implementation.  It must come before gtest-internal-inl.h is
 // included, or there will be a compiler error.  This trick is to
 // prevent a user from accidentally including gtest-internal-inl.h in
-// his code.
+// their code.
 #define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
 #undef GTEST_IMPLEMENTATION_

--- a/utils/unittest/googletest/src/gtest.cc
+++ b/utils/unittest/googletest/src/gtest.cc
@@ -1970,7 +1970,7 @@ bool Test::HasSameFixtureClass() {
 
     if (first_is_TEST || this_is_TEST) {
       // The user mixed TEST and TEST_F in this test case - we'll tell
-      // him/her how to fix it.
+      // them how to fix it.
 
       // Gets the name of the TEST and the name of the TEST_F.  Note
       // that first_is_TEST and this_is_TEST cannot both be true, as
@@ -1991,7 +1991,7 @@ bool Test::HasSameFixtureClass() {
           << "case.";
     } else {
       // The user defined two fixture classes with the same name in
-      // two namespaces - we'll tell him/her how to fix it.
+      // two namespaces - we'll tell them how to fix it.
       ADD_FAILURE()
           << "All tests in the same test case must use the same test fixture\n"
           << "class.  However, in test case "


### PR DESCRIPTION
This pull request helps make the swift-llvm project more inclusive to others.

There's quite a bit of exclusive language in here, I don't think we as a community should stand for it!
