### PR TITLE
[SystemZ] Fix register ordering for BinaryRRF instructions

### DIFF
--- a/lib/Target/SystemZ/SystemZInstrFormats.td
+++ b/lib/Target/SystemZ/SystemZInstrFormats.td
@@ -1391,9 +1391,9 @@ class BinaryRRE<string mnemonic, bits<16> opcode, SDPatternOperator operator,
 
 class BinaryRRF<string mnemonic, bits<16> opcode, SDPatternOperator operator,
                 RegisterOperand cls1, RegisterOperand cls2>
-  : InstRRF<opcode, (outs cls1:$R1), (ins cls1:$R3, cls2:$R2),
+  : InstRRF<opcode, (outs cls1:$R1), (ins cls1:$R2, cls2:$R3),
             mnemonic#"r\t$R1, $R3, $R2",
-            [(set cls1:$R1, (operator cls1:$R3, cls2:$R2))]> {
+            [(set cls1:$R1, (operator cls1:$R2, cls2:$R3))]> {
   let OpKey = mnemonic ## cls1;
   let OpType = "reg";
   let R4 = 0;

--- a/test/CodeGen/SystemZ/fp-copysign-01.ll
+++ b/test/CodeGen/SystemZ/fp-copysign-01.ll
@@ -11,7 +11,7 @@ declare fp128 @copysignl(fp128, fp128) readnone
 define float @f1(float %a, float %b) {
 ; CHECK-LABEL: f1:
 ; CHECK-NOT: %f2
-; CHECK: cpsdr %f0, %f0, %f2
+; CHECK: cpsdr %f0, %f2, %f0
 ; CHECK: br %r14
   %res = call float @copysignf(float %a, float %b) readnone
   ret float %res
@@ -21,7 +21,7 @@ define float @f1(float %a, float %b) {
 define float @f2(float %a, double %bd) {
 ; CHECK-LABEL: f2:
 ; CHECK-NOT: %f2
-; CHECK: cpsdr %f0, %f0, %f2
+; CHECK: cpsdr %f0, %f2, %f0
 ; CHECK: br %r14
   %b = fptrunc double %bd to float
   %res = call float @copysignf(float %a, float %b) readnone
@@ -33,7 +33,7 @@ define float @f3(float %a, fp128 *%bptr) {
 ; CHECK-LABEL: f3:
 ; CHECK: ld [[BHIGH:%f[0-7]]], 0(%r2)
 ; CHECK: ld [[BLOW:%f[0-7]]], 8(%r2)
-; CHECK: cpsdr %f0, %f0, [[BHIGH]]
+; CHECK: cpsdr %f0, [[BHIGH]], %f0
 ; CHECK: br %r14
   %bl = load volatile fp128 , fp128 *%bptr
   %b = fptrunc fp128 %bl to float
@@ -45,7 +45,7 @@ define float @f3(float %a, fp128 *%bptr) {
 define double @f4(double %a, float %bf) {
 ; CHECK-LABEL: f4:
 ; CHECK-NOT: %f2
-; CHECK: cpsdr %f0, %f0, %f2
+; CHECK: cpsdr %f0, %f2, %f0
 ; CHECK: br %r14
   %b = fpext float %bf to double
   %res = call double @copysign(double %a, double %b) readnone
@@ -56,7 +56,7 @@ define double @f4(double %a, float %bf) {
 define double @f5(double %a, double %b) {
 ; CHECK-LABEL: f5:
 ; CHECK-NOT: %f2
-; CHECK: cpsdr %f0, %f0, %f2
+; CHECK: cpsdr %f0, %f2, %f0
 ; CHECK: br %r14
   %res = call double @copysign(double %a, double %b) readnone
   ret double %res
@@ -67,7 +67,7 @@ define double @f6(double %a, fp128 *%bptr) {
 ; CHECK-LABEL: f6:
 ; CHECK: ld [[BHIGH:%f[0-7]]], 0(%r2)
 ; CHECK: ld [[BLOW:%f[0-7]]], 8(%r2)
-; CHECK: cpsdr %f0, %f0, [[BHIGH]]
+; CHECK: cpsdr %f0, [[BHIGH]], %f0
 ; CHECK: br %r14
   %bl = load volatile fp128 , fp128 *%bptr
   %b = fptrunc fp128 %bl to double
@@ -82,7 +82,7 @@ define void @f7(fp128 *%cptr, fp128 *%aptr, float %bf) {
 ; CHECK-LABEL: f7:
 ; CHECK: ld [[AHIGH:%f[0-7]]], 0(%r3)
 ; CHECK: ld [[ALOW:%f[0-7]]], 8(%r3)
-; CHECK: cpsdr [[AHIGH]], [[AHIGH]], %f0
+; CHECK: cpsdr [[AHIGH]], %f0, [[AHIGH]]
 ; CHECK: std [[AHIGH]], 0(%r2)
 ; CHECK: std [[ALOW]], 8(%r2)
 ; CHECK: br %r14
@@ -98,7 +98,7 @@ define void @f8(fp128 *%cptr, fp128 *%aptr, double %bd) {
 ; CHECK-LABEL: f8:
 ; CHECK: ld [[AHIGH:%f[0-7]]], 0(%r3)
 ; CHECK: ld [[ALOW:%f[0-7]]], 8(%r3)
-; CHECK: cpsdr [[AHIGH]], [[AHIGH]], %f0
+; CHECK: cpsdr [[AHIGH]], %f0, [[AHIGH]]
 ; CHECK: std [[AHIGH]], 0(%r2)
 ; CHECK: std [[ALOW]], 8(%r2)
 ; CHECK: br %r14
@@ -116,7 +116,7 @@ define void @f9(fp128 *%cptr, fp128 *%aptr, fp128 *%bptr) {
 ; CHECK: ld [[AHIGH:%f[0-7]]], 0(%r3)
 ; CHECK: ld [[ALOW:%f[0-7]]], 8(%r3)
 ; CHECK: ld [[BHIGH:%f[0-7]]], 0(%r4)
-; CHECK: cpsdr [[AHIGH]], [[AHIGH]], [[BHIGH]]
+; CHECK: cpsdr [[AHIGH]], [[BHIGH]], [[AHIGH]]
 ; CHECK: std [[AHIGH]], 0(%r2)
 ; CHECK: std [[ALOW]], 8(%r2)
 ; CHECK: br %r14


### PR DESCRIPTION
Summary:
The ordering of registers in BinaryRRF instructions are wrong, and
affects the copysign instruction (CPSDR). This results in the wrong
magnitude and sign being set.

Author: zhanjunl

Reviewers: kbarton, uweigand

Subscribers: llvm-commits

Differential Revision: http://reviews.llvm.org/D20308

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@269922 91177308-0d34-0410-b5e6-96231b3b80d8
