### PR TITLE
Prevent unsafe use of llvm::StringSwitch.

### DIFF
--- a/include/llvm/ADT/StringSwitch.h
+++ b/include/llvm/ADT/StringSwitch.h
@@ -53,6 +53,13 @@ public:
   explicit StringSwitch(StringRef S)
   : Str(S), Result(nullptr) { }
 
+  // StringSwitch is not copyable.
+  StringSwitch(const StringSwitch &) = delete;
+  StringSwitch(StringSwitch &&) = default;
+  void operator=(const StringSwitch &) = delete;
+  StringSwitch &operator=(StringSwitch &&) = default;
+  ~StringSwitch() = default;
+
   template<unsigned N>
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   StringSwitch& Case(const char (&S)[N], const T& Value) {

--- a/include/llvm/ADT/StringSwitch.h
+++ b/include/llvm/ADT/StringSwitch.h
@@ -55,9 +55,17 @@ public:
 
   // StringSwitch is not copyable.
   StringSwitch(const StringSwitch &) = delete;
-  StringSwitch(StringSwitch &&) = default;
   void operator=(const StringSwitch &) = delete;
-  StringSwitch &operator=(StringSwitch &&) = default;
+
+  StringSwitch(StringSwitch &&other) {
+    *this = std::move(other);
+  }
+  StringSwitch &operator=(StringSwitch &&other) {
+    Str = other.Str;
+    Result = other.Result;
+    return *this;
+  }
+
   ~StringSwitch() = default;
 
   template<unsigned N>


### PR DESCRIPTION
Disable the copy constructor to prevent StringSwitch from being used with 'auto', which is important because the inferred type is StringSwitch rather than the result type. This is a problem because StringSwitch stores addresses of temporary values rather than copying or moving the value into its own storage.
