### PR TITLE
cmake: Install CheckAtomic.cmake (needed by lldb)

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -118,6 +118,5 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     PATTERN LLVMConfig.cmake EXCLUDE
     PATTERN LLVMConfigVersion.cmake EXCLUDE
     PATTERN LLVM-Config.cmake EXCLUDE
-    PATTERN GetHostTriple.cmake EXCLUDE
-    PATTERN CheckAtomic.cmake EXCLUDE)
+    PATTERN GetHostTriple.cmake EXCLUDE)
 endif()


### PR DESCRIPTION
Summary:
Install CheckAtomic.cmake along with other LLVM modules, therefore making it possible for other projects to use it. This file is needed for LLDB to be built standalone, and installing it was suggested in https://reviews.llvm.org/D23881.

Patch by: Michał Górny

Reviewers: krytarowski, zturner, eugenis, jyknight, labath, beanz

Subscribers: beanz, llvm-commits

Differential Revision: https://reviews.llvm.org/D23887

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@279777 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit fdda55bb968b2c39da76baa85a29114f53154944)
