### PR TITLE
Disallow ArrayRef assignment from temporaries.

### DIFF
--- a/include/llvm/ADT/ArrayRef.h
+++ b/include/llvm/ADT/ArrayRef.h
@@ -203,6 +203,22 @@ namespace llvm {
       return Data[Index];
     }
 
+    /// Disallow accidental assignment from a temporary.
+    ///
+    /// The declaration here is extra complicated so that "arrayRef = {}"
+    /// continues to select the move assignment operator.
+    template <typename U>
+    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
+    operator=(U &&Temporary) = delete;
+
+    /// Disallow accidental assignment from a temporary.
+    ///
+    /// The declaration here is extra complicated so that "arrayRef = {}"
+    /// continues to select the move assignment operator.
+    template <typename U>
+    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
+    operator=(std::initializer_list<U>) = delete;
+
     /// @}
     /// @name Expensive Operations
     /// @{

--- a/unittests/ADT/ArrayRefTest.cpp
+++ b/unittests/ADT/ArrayRefTest.cpp
@@ -31,6 +31,26 @@ static_assert(
     !std::is_convertible<ArrayRef<volatile int *>, ArrayRef<int *>>::value,
     "Removing volatile");
 
+// Check that we can't accidentally assign a temporary location to an ArrayRef.
+// (Unfortunately we can't make use of the same thing with constructors.)
+//
+// Disable this check under MSVC; even MSVC 2015 isn't inconsistent between
+// std::is_assignable and actually writing such an assignment.
+#if !defined(_MSC_VER)
+static_assert(
+    !std::is_assignable<ArrayRef<int *>, int *>::value,
+    "Assigning from single prvalue element");
+static_assert(
+    !std::is_assignable<ArrayRef<int *>, int * &&>::value,
+    "Assigning from single xvalue element");
+static_assert(
+    std::is_assignable<ArrayRef<int *>, int * &>::value,
+    "Assigning from single lvalue element");
+static_assert(
+    !std::is_assignable<ArrayRef<int *>, std::initializer_list<int *>>::value,
+    "Assigning from an initializer list");
+#endif
+
 namespace {
 
 TEST(ArrayRefTest, AllocatorCopy) {
@@ -144,6 +164,14 @@ TEST(ArrayRefTest, InitializerList) {
   EXPECT_EQ(2, A[1]);
 
   ArgTest12({1, 2});
+}
+
+TEST(ArrayRefTest, EmptyInitializerList) {
+  ArrayRef<int> A = {};
+  EXPECT_TRUE(A.empty());
+
+  A = {};
+  EXPECT_TRUE(A.empty());
 }
 
 // Test that makeArrayRef works on ArrayRef (no-op)


### PR DESCRIPTION
Without this, the following statements will create ArrayRefs that refer to temporary storage that goes out of scope by the end of the line:

``` c++
someArrayRef = getSingleElement();
someArrayRef = {elem1, elem2};
```

Note that the constructor still has this problem:

``` c++
ArrayRef<Element> someArrayRef = getSingleElement();
ArrayRef<Element> someArrayRef = {elem1, elem2};
```

but that's a little harder to get rid of because we want to be able to use this in calls:

``` c++
takesArrayRef(getSingleElement());
takesArrayRef({elem1, elem2});
```

Part of rdar://problem/16375365. Reviewed by @dexonsmith.
