### PR TITLE
Disallow StringRef assignment from temporary std::strings

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -226,6 +226,15 @@ namespace llvm {
       return Data[Index];
     }
 
+    /// Disallow accidental assignment from a temporary std::string.
+    ///
+    /// The declaration here is extra complicated so that `stringRef = {}`
+    /// and `stringRef = "abc"` continue to select the move assignment operator.
+    template <typename T>
+    typename std::enable_if<std::is_same<T, std::string>::value,
+                            StringRef>::type &
+    operator=(T &&Str) = delete;
+
     /// @}
     /// @name Type Conversions
     /// @{


### PR DESCRIPTION
Similar to #26, this prevents accidentally referring to temporary storage that goes out of scope by the end of the statement:

``` c++
someStringRef = getStringByValue();
someStringRef = (Twine("-") + otherString).str();
```

Note that once again the constructor still has this problem:

``` c++
StringRef someStringRef = getStringByValue();
```

because once again we occasionally rely on this in calls:

```
takesStringRef(getStringByValue());
takesStringRef(Twine("-") + otherString);
```

Still, it's a step.

Reviewed by @dexonsmith over on reviews.llvm.org.