### PR TITLE
Remove compatibility constructor for NamedRegionTimer, TimerGroup once swift is fixed.

### DIFF
--- a/include/llvm/Support/Timer.h
+++ b/include/llvm/Support/Timer.h
@@ -161,8 +161,6 @@ struct NamedRegionTimer : public TimeRegion {
   explicit NamedRegionTimer(StringRef Name, StringRef Description,
                             StringRef GroupName,
                             StringRef GroupDescription, bool Enabled = true);
-  /// Backward compatibility cludge to unbreak the swift build.
-  explicit NamedRegionTimer(StringRef Name, StringRef GroupName);
 };
 
 /// The TimerGroup class is used to group together related timers into a single
@@ -182,8 +180,6 @@ class TimerGroup {
 
 public:
   explicit TimerGroup(StringRef Name, StringRef Description);
-  /// Backward compatibility cludge to unbreak the swift build.
-  explicit TimerGroup(StringRef Name);
   ~TimerGroup();
 
   void setName(StringRef NewName, StringRef NewDescription) {

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -219,9 +219,6 @@ NamedRegionTimer::NamedRegionTimer(StringRef Name, StringRef Description,
                  : &NamedGroupedTimers->get(Name, Description, GroupName,
                                             GroupDescription)) {}
 
-NamedRegionTimer::NamedRegionTimer(StringRef Name, StringRef GroupName)
-  : TimeRegion(&NamedGroupedTimers->get(Name, Name, GroupName, GroupName)) {}
-
 //===----------------------------------------------------------------------===//
 //   TimerGroup Implementation
 //===----------------------------------------------------------------------===//
@@ -229,9 +226,6 @@ NamedRegionTimer::NamedRegionTimer(StringRef Name, StringRef GroupName)
 /// This is the global list of TimerGroups, maintained by the TimerGroup
 /// ctor/dtor and is protected by the TimerLock lock.
 static TimerGroup *TimerGroupList = nullptr;
-
-TimerGroup::TimerGroup(StringRef Name)
-  : TimerGroup(Name, Name) { }
 
 TimerGroup::TimerGroup(StringRef Name, StringRef Description)
   : Name(Name.begin(), Name.end()),


### PR DESCRIPTION
Remove compatibility constructor for NamedRegionTimer, TimerGroup once swift is fixed.