### PR TITLE
[swift-4.0-branch] Add workaround for MSVC bug

### DIFF
--- a/include/llvm/Support/TrailingObjects.h
+++ b/include/llvm/Support/TrailingObjects.h
@@ -231,7 +231,14 @@ protected:
 /// See the file comment for details on the usage of the
 /// TrailingObjects type.
 template <typename BaseTy, typename... TrailingTys>
+
+// Work around MSVC build error: cannot access inaccessible struct declared
+// in class'llvm::trailing_objects_internal::TrailingObjectsBase'
+#if defined(_MSC_VER)
+class TrailingObjects : protected trailing_objects_internal::TrailingObjectsImpl<
+#else
 class TrailingObjects : private trailing_objects_internal::TrailingObjectsImpl<
+#endif
                             trailing_objects_internal::AlignmentCalcHelper<
                                 TrailingTys...>::Alignment,
                             BaseTy, TrailingObjects<BaseTy, TrailingTys...>,


### PR DESCRIPTION
See #33

The problem is that MSVC doesn't recognise the following syntax, reporting multiple errors [here](https://github.com/apple/swift/blob/master/include/swift/AST/Expr.h#L661):
```
  size_t numTrailingObjects(
      typename TrailingObjects::template OverloadToken<SourceLoc>) const {
    return asDerived().hasArgumentLabelLocs()
             ? asDerived().getNumArguments()
             : 0;
  }
```

For some reason, MSVC ignores the fact that we gave friend access to `llvm::TrailingObjects` [here]().

Note that the Swift source code also has to be modified, as this is not enough. This is the new source code, that fully compiles after this change!
```
  // Work around MSVC bug: can't infer llvm::trailing_objects_internal, even though we granted friend access to it
	size_t numTrailingObjects(
		llvm::trailing_objects_internal::TrailingObjectsBase::OverloadToken<Identifier>) const {
		typename TrailingObjects::template OverloadToken<Identifier>) const {
    return asDerived().getNumArguments();
  }
```