### PR TITLE
Disable LLVM ABI breaking checks by default when building swift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,8 +414,13 @@ option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING
   "Enable abi-breaking checks.  Can be WITH_ASSERTS, FORCE_ON or FORCE_OFF.")
 
+set(default_LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING OFF)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tools/swift)
+  set(default_LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING ON)
+endif()
 option(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
-  "Disable abi-breaking checks mismatch detection at link-tim." OFF)
+  "Disable abi-breaking checks mismatch detection at link-tim."
+  ${default_LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING})
 
 option(LLVM_FORCE_USE_OLD_HOST_TOOLCHAIN
        "Set to ON to force using an old, unsupported host toolchain." OFF)


### PR DESCRIPTION
The LLVM ABI breaking checks require that all uses of llvm's ADT library must also link libSupport. Parts of the Swift standard library use ADT without Support intentionally. To make this work we must disable the ABI breaking checks when building swift.

This patch changes the default value of the option that controls the ABI breaking checks to disable the checks by default if the swift source directory is present in the LLVM build tree.

Currently disabling these checks is handled by the swift build-script, but to support non-build-script builds having the default work is ideal.