### PR TITLE
Cherry pick LLVM::None MSVC fixes to swift-4.0-branch

### DIFF
--- a/include/llvm/ADT/None.h
+++ b/include/llvm/ADT/None.h
@@ -19,7 +19,8 @@
 namespace llvm {
 /// \brief A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
-enum class NoneType { None };
+// (constant value 1 in an attempt to workaround MSVC build issue... )
+enum class NoneType { None = 1 };
 const NoneType None = NoneType::None;
 }
 

--- a/include/llvm/ADT/None.h
+++ b/include/llvm/ADT/None.h
@@ -20,7 +20,7 @@ namespace llvm {
 /// \brief A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
 enum class NoneType { None };
-const NoneType None = None;
+const NoneType None = NoneType::None;
 }
 
 #endif


### PR DESCRIPTION
Never made it to this branch (or stable, but has for upstream-with-swift) for some reason - I think it was merged simultaneously when swift-4.0-branched