### PR TITLE
Adding const overloads of operator* and operator-> for DenseSet iterators

### DIFF
--- a/include/llvm/ADT/DenseSet.h
+++ b/include/llvm/ADT/DenseSet.h
@@ -104,7 +104,9 @@ public:
     Iterator(const typename MapTy::iterator &i) : I(i) {}
 
     ValueT &operator*() { return I->getFirst(); }
+    const ValueT &operator*() const { return I->getFirst(); }
     ValueT *operator->() { return &I->getFirst(); }
+    const ValueT *operator->() const { return &I->getFirst(); }
 
     Iterator& operator++() { ++I; return *this; }
     Iterator operator++(int) { auto T = *this; ++I; return T; }
@@ -125,8 +127,8 @@ public:
 
     ConstIterator(const typename MapTy::const_iterator &i) : I(i) {}
 
-    const ValueT &operator*() { return I->getFirst(); }
-    const ValueT *operator->() { return &I->getFirst(); }
+    const ValueT &operator*() const { return I->getFirst(); }
+    const ValueT *operator->() const { return &I->getFirst(); }
 
     ConstIterator& operator++() { ++I; return *this; }
     ConstIterator operator++(int) { auto T = *this; ++I; return T; }


### PR DESCRIPTION
This fixes some problems when building ClangDiagnostics.cpp on Visual Studio 2017 RC. As far as I understand, there was a change in the implementation of the constructor for std::vector with two iterator parameters, which in our case causes an attempt to dereference const Iterator objects. Since there was no overload for a const Iterator, the compile would fail.

Patch by Hugo Puhlmann!

Differential Revision: https://reviews.llvm.org/D28726

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@292034 91177308-0d34-0410-b5e6-96231b3b80d8