### PR TITLE
[lit] Modify LIT to accept environment variable LIT_FILTER to select …

### DIFF
--- a/docs/CommandGuide/lit.rst
+++ b/docs/CommandGuide/lit.rst
@@ -152,6 +152,13 @@ SELECTION OPTIONS
 
  Run the tests in a random order.
 
+.. option:: --filter=REGEXP
+
+  Run only those tests whose name matches the regular expression specified in
+  ``REGEXP``. The environment variable ``LIT_FILTER`` can be also used in place
+  of this option, which is especially useful in environments where the call
+  to ``lit`` is issued indirectly.
+
 ADDITIONAL OPTIONS
 ------------------
 

--- a/utils/lit/lit/main.py
+++ b/utils/lit/lit/main.py
@@ -258,7 +258,8 @@ def main_with_tmp(builtinParameters):
     selection_group.add_argument("--filter", metavar="REGEX",
                      help=("Only run tests with paths matching the given "
                            "regular expression"),
-                     action="store", default=None)
+                     action="store",
+                     default=os.environ.get("LIT_FILTER"))
 
     debug_group = parser.add_argument_group("Debug and Experimental Options")
     debug_group.add_argument("--debug",


### PR DESCRIPTION
…tests.

This is especially useful when lit is invoked indirectly by the build
system, and additional arguments can not be easily specified.

Differential Revision: https://reviews.llvm.org/D35091

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@307339 91177308-0d34-0410-b5e6-96231b3b80d8