### PR TITLE
Fix swift error throwing on non-darwin ARM platforms

### DIFF
--- a/lib/Target/ARM/ARMBaseRegisterInfo.cpp
+++ b/lib/Target/ARM/ARMBaseRegisterInfo.cpp
@@ -82,7 +82,7 @@ ARMBaseRegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
     }
   }
 
-  if (STI.isTargetDarwin() && STI.getTargetLowering()->supportSwiftError() &&
+  if (STI.getTargetLowering()->supportSwiftError() &&
       F->getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return CSR_iOS_SwiftError_SaveList;
 
@@ -110,7 +110,7 @@ ARMBaseRegisterInfo::getCallPreservedMask(const MachineFunction &MF,
     // This is academic becase all GHC calls are (supposed to be) tail calls
     return CSR_NoRegs_RegMask;
 
-  if (STI.isTargetDarwin() && STI.getTargetLowering()->supportSwiftError() &&
+  if (STI.getTargetLowering()->supportSwiftError() &&
       MF.getFunction()->getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return CSR_iOS_SwiftError_RegMask;
 


### PR DESCRIPTION
A minor change to get Swift Error throwing to work on non-darwin ARM32 platforms (e.g. Android.) Without this change, code generated saves and restores ARM register r8 at the entry and returns of a function that throws. As r8 is used as a virtual return value for the object being thrown this gets overwritten by the restore and calling code is unable to catch the error. This was causing do/try/catch not to work on Android as it is an ARM32 platform that does not satisfy "STI.isTargetDarwin()"

Addresses [SR-5438](https://bugs.swift.org/browse/SR-5438)