### PR TITLE
master-next: Temporary workaround for llvm r315852.

### DIFF
--- a/include/llvm/Transforms/Utils/FunctionComparator.h
+++ b/include/llvm/Transforms/Utils/FunctionComparator.h
@@ -33,7 +33,6 @@ class APInt;
 class BasicBlock;
 class Constant;
 class Function;
-class GlobalValue;
 class InlineAsm;
 class Instruction;
 class MDNode;
@@ -53,14 +52,14 @@ class Value;
 /// compare those, but this would not work for stripped bitcodes or for those
 /// few symbols without a name.
 class GlobalNumberState {
-  struct Config : ValueMapConfig<GlobalValue *> {
+  struct Config : ValueMapConfig<Value *> {
     enum { FollowRAUW = false };
   };
 
   // Each GlobalValue is mapped to an identifier. The Config ensures when RAUW
   // occurs, the mapping does not change. Tracking changes is unnecessary, and
   // also problematic for weak symbols (which may be overwritten).
-  using ValueNumberMap = ValueMap<GlobalValue *, uint64_t, Config>;
+  using ValueNumberMap = ValueMap<Value *, uint64_t, Config>;
   ValueNumberMap GlobalNumbers;
 
   // The next unused serial number to assign to a global.
@@ -69,7 +68,7 @@ class GlobalNumberState {
 public:
   GlobalNumberState() = default;
 
-  uint64_t getNumber(GlobalValue* Global) {
+  uint64_t getNumber(Value* Global) {
     ValueNumberMap::iterator MapIter;
     bool Inserted;
     std::tie(MapIter, Inserted) = GlobalNumbers.insert({Global, NextNumber});
@@ -220,7 +219,7 @@ protected:
 
   /// Compares two global values by number. Uses the GlobalNumbersState to
   /// identify the same gobals across function calls.
-  int cmpGlobalValues(GlobalValue *L, GlobalValue *R) const;
+  int cmpGlobalValues(Value *L, Value *R) const;
 
   /// Assign or look up previously assigned numbers for the two values, and
   /// return whether the numbers are equal. Numbers are assigned in the order

--- a/lib/Transforms/Utils/FunctionComparator.cpp
+++ b/lib/Transforms/Utils/FunctionComparator.cpp
@@ -253,8 +253,8 @@ int FunctionComparator::cmpConstants(const Constant *L,
   if (!L->isNullValue() && R->isNullValue())
     return -1;
 
-  auto GlobalValueL = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(L));
-  auto GlobalValueR = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(R));
+  auto GlobalValueL = const_cast<Value *>(dyn_cast<Value>(L));
+  auto GlobalValueR = const_cast<Value *>(dyn_cast<Value>(R));
   if (GlobalValueL && GlobalValueR) {
     return cmpGlobalValues(GlobalValueL, GlobalValueR);
   }
@@ -383,7 +383,7 @@ int FunctionComparator::cmpConstants(const Constant *L,
   }
 }
 
-int FunctionComparator::cmpGlobalValues(GlobalValue *L, GlobalValue *R) const {
+int FunctionComparator::cmpGlobalValues(Value *L, Value *R) const {
   uint64_t LNumber = GlobalNumbers->getNumber(L);
   uint64_t RNumber = GlobalNumbers->getNumber(R);
   return cmpNumbers(LNumber, RNumber);


### PR DESCRIPTION
The change in llvm r315852 is causing an assertion failure for Swift.
I've notified the author of that change and am hoping for a fix. In the
meantime, here is a workaround. I'm doing this instead of reverting the
offending commit from swift-llvm's upstream-with-swift branch in anticipation
of a merge conflict from the hoped-for fix. I'll remove this workaround when
there is a real fix.

rdar://problem/35017353