### PR TITLE
Revert "master-next: Temporary workaround for llvm r315852."

### DIFF
--- a/include/llvm/Transforms/Utils/FunctionComparator.h
+++ b/include/llvm/Transforms/Utils/FunctionComparator.h
@@ -33,6 +33,7 @@ class APInt;
 class BasicBlock;
 class Constant;
 class Function;
+class GlobalValue;
 class InlineAsm;
 class Instruction;
 class MDNode;
@@ -52,14 +53,14 @@ class Value;
 /// compare those, but this would not work for stripped bitcodes or for those
 /// few symbols without a name.
 class GlobalNumberState {
-  struct Config : ValueMapConfig<Value *> {
+  struct Config : ValueMapConfig<GlobalValue *> {
     enum { FollowRAUW = false };
   };
 
   // Each GlobalValue is mapped to an identifier. The Config ensures when RAUW
   // occurs, the mapping does not change. Tracking changes is unnecessary, and
   // also problematic for weak symbols (which may be overwritten).
-  using ValueNumberMap = ValueMap<Value *, uint64_t, Config>;
+  using ValueNumberMap = ValueMap<GlobalValue *, uint64_t, Config>;
   ValueNumberMap GlobalNumbers;
 
   // The next unused serial number to assign to a global.
@@ -68,7 +69,7 @@ class GlobalNumberState {
 public:
   GlobalNumberState() = default;
 
-  uint64_t getNumber(Value* Global) {
+  uint64_t getNumber(GlobalValue* Global) {
     ValueNumberMap::iterator MapIter;
     bool Inserted;
     std::tie(MapIter, Inserted) = GlobalNumbers.insert({Global, NextNumber});
@@ -219,7 +220,7 @@ protected:
 
   /// Compares two global values by number. Uses the GlobalNumbersState to
   /// identify the same gobals across function calls.
-  int cmpGlobalValues(Value *L, Value *R) const;
+  int cmpGlobalValues(GlobalValue *L, GlobalValue *R) const;
 
   /// Assign or look up previously assigned numbers for the two values, and
   /// return whether the numbers are equal. Numbers are assigned in the order

--- a/lib/Transforms/Utils/FunctionComparator.cpp
+++ b/lib/Transforms/Utils/FunctionComparator.cpp
@@ -253,8 +253,8 @@ int FunctionComparator::cmpConstants(const Constant *L,
   if (!L->isNullValue() && R->isNullValue())
     return -1;
 
-  auto GlobalValueL = const_cast<Value *>(dyn_cast<Value>(L));
-  auto GlobalValueR = const_cast<Value *>(dyn_cast<Value>(R));
+  auto GlobalValueL = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(L));
+  auto GlobalValueR = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(R));
   if (GlobalValueL && GlobalValueR) {
     return cmpGlobalValues(GlobalValueL, GlobalValueR);
   }
@@ -383,7 +383,7 @@ int FunctionComparator::cmpConstants(const Constant *L,
   }
 }
 
-int FunctionComparator::cmpGlobalValues(Value *L, Value *R) const {
+int FunctionComparator::cmpGlobalValues(GlobalValue *L, GlobalValue *R) const {
   uint64_t LNumber = GlobalNumbers->getNumber(L);
   uint64_t RNumber = GlobalNumbers->getNumber(R);
   return cmpNumbers(LNumber, RNumber);


### PR DESCRIPTION
This reverts commit ea55aaade6fb6211040ec040b1dbd64d93cab10a.

I had tested this with the Swift tests, but it looks like it breaks
some of the LLVM tests.