### PR TITLE
[SystemZ] Add support for the "o" inline asm constraint

### DIFF
--- a/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
+++ b/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
@@ -1379,8 +1379,11 @@ SelectInlineAsmMemoryOperand(const SDValue &Op,
     break;
   case InlineAsm::Constraint_T:
   case InlineAsm::Constraint_m:
+  case InlineAsm::Constraint_o:
     // Accept an address with a long displacement and an index.
     // m works the same as T, as this is the most general case.
+    // We don't really have any special handling of "offsettable"
+    // memory addresses, so just treat o the same as m.
     Form = SystemZAddressingMode::FormBDXNormal;
     DispRange = SystemZAddressingMode::Disp20Only;
     break;

--- a/lib/Target/SystemZ/SystemZISelLowering.h
+++ b/lib/Target/SystemZ/SystemZISelLowering.h
@@ -410,6 +410,8 @@ public:
       switch(ConstraintCode[0]) {
       default:
         break;
+      case 'o':
+        return InlineAsm::Constraint_o;
       case 'Q':
         return InlineAsm::Constraint_Q;
       case 'R':

--- a/test/CodeGen/SystemZ/asm-05.ll
+++ b/test/CodeGen/SystemZ/asm-05.ll
@@ -1,4 +1,5 @@
 ; Test the "m" asm constraint, which is equivalent to "T".
+; Likewise for the "o" asm constraint.
 ;
 ; RUN: llc < %s -mtriple=s390x-linux-gnu -no-integrated-as | FileCheck %s
 
@@ -8,5 +9,14 @@ define void @f1(i64 %base) {
 ; CHECK: br %r14
   %addr = inttoptr i64 %base to i64 *
   call void asm "blah $0", "=*m" (i64 *%addr)
+  ret void
+}
+
+define void @f2(i64 %base) {
+; CHECK-LABEL: f2:
+; CHECK: blah 0(%r2)
+; CHECK: br %r14
+  %addr = inttoptr i64 %base to i64 *
+  call void asm "blah $0", "=*o" (i64 *%addr)
   ret void
 }


### PR DESCRIPTION
Need the fix below to compile libdispatch on s390x.  Thanks.

We don't really need any special handling of "offsettable"
memory addresses, but since some existing code uses inline
asm statements with the "o" constraint, add support for this
constraint for compatibility purposes.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@317807 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit b9cdeecf2548f080fc3afbc983d3d018b9780c77)