### PR TITLE
[Support] Use realpath(3) instead of trying to open a file.

### DIFF
--- a/lib/Support/Unix/Path.inc
+++ b/lib/Support/Unix/Path.inc
@@ -908,12 +908,12 @@ std::error_code real_path(const Twine &path, SmallVectorImpl<char> &dest,
     return real_path(Storage, dest, false);
   }
 
-  int fd;
-  std::error_code EC = openFileForRead(path, fd, &dest);
-
-  if (EC)
-    return EC;
-  ::close(fd);
+  SmallString<128> Storage;
+  StringRef P = path.toNullTerminatedStringRef(Storage);
+  char Buffer[PATH_MAX];
+  if (::realpath(P.begin(), Buffer) == nullptr)
+    return std::error_code(errno, std::generic_category());
+  dest.append(Buffer, Buffer + strlen(Buffer));
   return std::error_code();
 }
 

--- a/unittests/Support/Path.cpp
+++ b/unittests/Support/Path.cpp
@@ -564,6 +564,24 @@ TEST_F(FileSystemTest, RealPath) {
   ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory) + "/test1"));
 }
 
+#ifdef LLVM_ON_UNIX
+TEST_F(FileSystemTest, RealPathNoReadPerm) {
+  SmallString<64> Expanded;
+
+  ASSERT_NO_ERROR(
+    fs::create_directories(Twine(TestDirectory) + "/noreadperm"));
+  ASSERT_TRUE(fs::exists(Twine(TestDirectory) + "/noreadperm"));
+
+  fs::setPermissions(Twine(TestDirectory) + "/noreadperm", fs::no_perms);
+  fs::setPermissions(Twine(TestDirectory) + "/noreadperm", fs::all_exe);
+
+  ASSERT_NO_ERROR(fs::real_path(Twine(TestDirectory) + "/noreadperm", Expanded,
+                                false));
+
+  ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory) + "/noreadperm"));
+}
+#endif
+
 TEST_F(FileSystemTest, TempFiles) {
   // Create a temp file.
   int FileDescriptor;


### PR DESCRIPTION
If we don't have read permissions on the directory the call would
fail.

<rdar://problem/35871293>

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@322095 91177308-0d34-0410-b5e6-96231b3b80d8