### PR TITLE
Delete the copy constructor for llvm::yaml::Node

### DIFF
--- a/include/llvm/Support/YAMLParser.h
+++ b/include/llvm/Support/YAMLParser.h
@@ -125,6 +125,11 @@ public:
   Node(unsigned int Type, std::unique_ptr<Document> &, StringRef Anchor,
        StringRef Tag);
 
+  // It's not safe to copy YAML nodes; the document is streamed and the position
+  // is part of the state.
+  Node(const Node &) = delete;
+  void operator=(const Node &) = delete;
+
   void *operator new(size_t Size, BumpPtrAllocator &Alloc,
                      size_t Alignment = 16) noexcept {
     return Alloc.Allocate(Size, Alignment);


### PR DESCRIPTION
The nodes keep a reference back to the original document, but the document is streamed, not read all into memory at once, and the position is part of the state. If nodes are ever copied, the document position can end up being advanced more than once.

Cherry-pick of https://reviews.llvm.org/D44317, reviewed by @hyp. Did not affect LLVM or Clang but did affect clang-tools-extra (r328354).