### PR TITLE
Trivial typo in a source comment

### DIFF
--- a/lib/Support/YAMLTraits.cpp
+++ b/lib/Support/YAMLTraits.cpp
@@ -705,7 +705,7 @@ bool Output::canElideEmptySequence() {
   // the whole key/value can be not written.  But, that produces wrong yaml
   // if the key/value is the only thing in the map and the map is used in
   // a sequence.  This detects if the this sequence is the first key/value
-  // in map that itself is embedded in a sequnce.
+  // in map that itself is embedded in a sequence.
   if (StateStack.size() < 2)
     return true;
   if (StateStack.back() != inMapFirstKey)


### PR DESCRIPTION
Accidentally spotted a missing "e" in "sequence" (I made the same typo in a search ;-)
If I could only be as sure that "ExprSequnceContext" in the compiler source is a typo as well... ;-)