### PR TITLE
[cmake] Make check_linker_flags operate via linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if (POLICY CMP0051)
   cmake_policy(SET CMP0051 OLD)
 endif()
 
+if(POLICY CMP0056)
+  cmake_policy(SET CMP0056 NEW)
+endif()
+
 if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()

--- a/cmake/modules/CheckLinkerFlag.cmake
+++ b/cmake/modules/CheckLinkerFlag.cmake
@@ -1,8 +1,6 @@
 include(CheckCXXCompilerFlag)
 
 function(check_linker_flag flag out_var)
-  set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${flag}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${flag}")
   check_cxx_compiler_flag("" ${out_var})
-  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endfunction()


### PR DESCRIPTION
`check_linker_flags` currently sets the *compiler* flags (via
`CMAKE_REQUIRED_FLAGS`), and thus implicitly relies on cmake's default
behavior of passing the compiler flags to the linker. This breaks when
cmake's build rules have been altered to not pollute the link line with
compiler flags (which can be desirable for build cleanliness). Instead,
set `CMAKE_EXE_LINKER_FLAGS` explicitly and use `CMP0056` to ensure the
linker flags are passed along. Additionally, since we're inside a
function, we can just alter the variable directly (as the alteration
will be limited to the scope of the function) rather than saving and
restoring the old value.

Differential Revision: https://reviews.llvm.org/D39431

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@316972 91177308-0d34-0410-b5e6-96231b3b80d8