### PR TITLE
[Hashing] Forward-declare hash_value for tuples.

### DIFF
--- a/include/llvm/ADT/Hashing.h
+++ b/include/llvm/ADT/Hashing.h
@@ -119,6 +119,9 @@ hash_code hash_value(const std::pair<T, U> &arg);
 template <typename T>
 hash_code hash_value(const std::basic_string<T> &arg);
 
+/// \brief Compute a hash_code for a tuple.
+template <typename ...Ts>
+hash_code hash_value(const std::tuple<Ts...> &arg);
 
 /// \brief Override the execution seed with a fixed value.
 ///


### PR DESCRIPTION
This allows hash_combine to work on tuples containing no types within the
LLVM namespace, because two-phase name lookup is weird.
