### PR TITLE
Support: assume `std::is_final` with MSVC

### DIFF
--- a/include/llvm/Support/type_traits.h
+++ b/include/llvm/Support/type_traits.h
@@ -109,7 +109,7 @@ struct const_pointer_or_const_ref<
 // If the compiler supports detecting whether a class is final, define
 // an LLVM_IS_FINAL macro. If it cannot be defined properly, this
 // macro will be left undefined.
-#if __cplusplus >= 201402L
+#if __cplusplus >= 201402L || defined(_MSC_VER)
 #define LLVM_IS_FINAL(Ty) std::is_final<Ty>()
 #elif __has_feature(is_final) || LLVM_GNUC_PREREQ(4, 7, 0)
 #define LLVM_IS_FINAL(Ty) __is_final(Ty)


### PR DESCRIPTION
According to MSDN, Visual Studio 2015 included support for
std::is_final. Additionally, a bug in the Visual Studio compiler results
in the incorrect definition of __cplusplus. Due to the conditions in the
else case not holding either, we end up with no definition of
LLVM_IS_FINAL when building with MSVC. This has not yet been a problem
with LLVM/clang, however, the uses of LLVM_IS_FINAL is more prevalent in
swift, which uses the ADT library and causes issues when building lldb
with Visual Studio.

Workaround the issue by always assuming that the definition of
std::is_final is available with Visual Studio. Since we currently
require VS 2015+ for building LLVM, this condition should always hold
for the users in LLVM/clang (and for swift).

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@331282 91177308-0d34-0410-b5e6-96231b3b80d8