### PR TITLE
[4.2] commandLineFitsWithinSystemLimits Overestimates System Limits

### DIFF
--- a/lib/Support/Unix/Program.inc
+++ b/lib/Support/Unix/Program.inc
@@ -434,13 +434,24 @@ llvm::sys::writeFileWithEncoding(StringRef FileName, StringRef Contents,
 bool llvm::sys::commandLineFitsWithinSystemLimits(StringRef Program,
                                                   ArrayRef<const char *> Args) {
   static long ArgMax = sysconf(_SC_ARG_MAX);
+  // POSIX requires that _POSIX_ARG_MAX is 4096, which is the lowest possible
+  // value for ARG_MAX on a POSIX compliant system.
+  static long ArgMin = _POSIX_ARG_MAX;
+
+  // This the same baseline used by xargs.
+  long EffectiveArgMax = 128 * 1024;
+
+  if (EffectiveArgMax > ArgMax)
+    EffectiveArgMax = ArgMax;
+  else if (EffectiveArgMax < ArgMin)
+    EffectiveArgMax = ArgMin;
 
   // System says no practical limit.
   if (ArgMax == -1)
     return true;
 
   // Conservatively account for space required by environment variables.
-  long HalfArgMax = ArgMax / 2;
+  long HalfArgMax = EffectiveArgMax / 2;
 
   size_t ArgLength = Program.size() + 1;
   for (const char* Arg : Args) {


### PR DESCRIPTION
- **Explanation**: The function `llvm::sys::commandLineFitsWithinSystemLimits` appears to be overestimating the system limits. This issue was discovered while attempting to enable response files in the Swift compiler. There are some cases where the argument size for the job passes `commandLineFitsWithinSystemLimits`, but actually exceeds the real system limit, and the job fails. The proposed solution is to mirror the behavior of `xargs` in `commandLineFitsWithinSystemLimits`.

- **Scope**: Affects an API used to determine whether to use response files in Clang (and possibly soon Swift).

- **Risk**: Low. This makes the check more conservative.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: Alexander Kornienko from Google, me. (Patch by @dabelknap.)