### PR TITLE
Revert "[upstream-with-swift] Temporary workaround for LLVM r334283"

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -725,12 +725,7 @@ namespace llvm {
     /// \returns The split substrings.
     LLVM_NODISCARD
     std::pair<StringRef, StringRef> split(char Separator) const {
-      // FIXME: temporary workaround for LLVM r334283 (rdar://problem/41029268)
-      // return split(StringRef(&Separator, 1));
-      size_t Idx = find(Separator);
-      if (Idx == npos)
-        return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), slice(Idx+1, npos));
+      return split(StringRef(&Separator, 1));
     }
 
     /// Split into two substrings around the first occurrence of a separator
@@ -816,12 +811,7 @@ namespace llvm {
     /// \return - The split substrings.
     LLVM_NODISCARD
     std::pair<StringRef, StringRef> rsplit(char Separator) const {
-      // FIXME: temporary workaround for LLVM r334283 (rdar://problem/41029268)
-      // return rsplit(StringRef(&Separator, 1));
-      size_t Idx = rfind(Separator);
-      if (Idx == npos)
-        return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), slice(Idx+1, npos));
+      return rsplit(StringRef(&Separator, 1));
     }
 
     /// Return string with consecutive \p Char characters starting from the


### PR DESCRIPTION
I changed Swift to avoid using StringRef::split and rsplit in contexts that do not link with libSupport.a (https://github.com/apple/swift/pull/17308), so this workaround is no longer needed.