### PR TITLE
[WIP] What happens when you implement Optional with PointerIntPair?

### DIFF
--- a/include/llvm/Support/PointerLikeTypeTraits.h
+++ b/include/llvm/Support/PointerLikeTypeTraits.h
@@ -111,6 +111,22 @@ template <> struct PointerLikeTypeTraits<uintptr_t> {
   enum { NumLowBitsAvailable = 0 };
 };
 
+// Provide PointerLikeTypeTraits for function pointers.
+template <typename Ret, typename ...Args>
+struct PointerLikeTypeTraits<Ret(*)(Args...)> {
+  using FnType = Ret(*)(Args...);
+
+  static inline void *getAsVoidPointer(FnType P) {
+    return reinterpret_cast<void *>(P);
+  }
+  static inline uintptr_t getFromVoidPointer(void *P) {
+    return reinterpret_cast<FnType>(P);
+  }
+
+  // Don't assume anything about the alignment of functions.
+  enum { NumLowBitsAvailable = 0 };
+};
+
 } // end namespace llvm
 
 #endif


### PR DESCRIPTION
Nerd sniped by @benlangmuir. This is using the version of llvm::Optional from upstream-with-swift, which already has some support for swapping out storage implementations.