### PR TITLE
For transitory purposes, define LLVM_DEBUG to be the same as DEBUG

### DIFF
--- a/include/llvm/Support/Debug.h
+++ b/include/llvm/Support/Debug.h
@@ -117,6 +117,9 @@ raw_ostream &dbgs();
 //
 #define DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
 
+// Transitory measure to get people onto LLVM_DEBUG for new code.
+#define LLVM_DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
+
 } // end namespace llvm
 
 #endif // LLVM_SUPPORT_DEBUG_H


### PR DESCRIPTION
upstream-with-swift only supports LLVM_DEBUG. Let's start getting off of DEBUG now.

This PR is deliberately targeted at the `stable` branch. That is, this will not affect Swift 4.2, and it will get overwritten the next time we rebranch Clang from upstream-with-swift. It's purely to keep from breaking Swift's master-next branch while we continue to commit to Swift master.