### PR TITLE
[Support] Add a public API to allow clearing all (static) timer groups.

### DIFF
--- a/include/llvm/Support/Timer.h
+++ b/include/llvm/Support/Timer.h
@@ -206,15 +206,23 @@ public:
     Description.assign(NewDescription.begin(), NewDescription.end());
   }
 
-  /// Print any started timers in this group and zero them.
+  /// Print any started timers in this group.
   void print(raw_ostream &OS);
 
-  /// This static method prints all timers and clears them all out.
+  /// Clear all timers in this group.
+  void clear();
+
+  /// This static method prints all timers.
   static void printAll(raw_ostream &OS);
+
+  /// Clear out all timers. This is mostly used to disable automatic
+  /// printing on shutdown, when timers have already been printed explicitly
+  /// using \c printAll or \c printJSONValues.
+  static void clearAll();
 
   const char *printJSONValues(raw_ostream &OS, const char *delim);
 
-  /// Prints all timers as JSON key/value pairs, and clears them all out.
+  /// Prints all timers as JSON key/value pairs.
   static const char *printAllJSONValues(raw_ostream &OS, const char *delim);
 
   /// Ensure global timer group lists are initialized. This function is mostly

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -343,8 +343,7 @@ void TimerGroup::PrintQueuedTimers(raw_ostream &OS) {
 }
 
 void TimerGroup::prepareToPrintList() {
-  // See if any of our timers were started, if so add them to TimersToPrint and
-  // reset them.
+  // See if any of our timers were started, if so add them to TimersToPrint.
   for (Timer *T = FirstTimer; T; T = T->Next) {
     if (!T->hasTriggered()) continue;
     bool WasRunning = T->isRunning();
@@ -368,11 +367,23 @@ void TimerGroup::print(raw_ostream &OS) {
     PrintQueuedTimers(OS);
 }
 
+void TimerGroup::clear() {
+  sys::SmartScopedLock<true> L(*TimerLock);
+  for (Timer *T = FirstTimer; T; T = T->Next)
+    T->clear();
+}
+
 void TimerGroup::printAll(raw_ostream &OS) {
   sys::SmartScopedLock<true> L(*TimerLock);
 
   for (TimerGroup *TG = TimerGroupList; TG; TG = TG->Next)
     TG->print(OS);
+}
+
+void TimerGroup::clearAll() {
+  sys::SmartScopedLock<true> L(*TimerLock);
+  for (TimerGroup *TG = TimerGroupList; TG; TG = TG->Next)
+    TG->clear();
 }
 
 void TimerGroup::printJSONValue(raw_ostream &OS, const PrintRecord &R,


### PR DESCRIPTION
Cherry-pick of a minor upstream change that lets us turn back _off_ the annoying automatic printout of timer groups when stats-output-dir is active in swiftc (due to an earlier upstream change a few months back that accidentally turned it on).

Summary:
Formerly, all timer groups were automatically cleared when printed out. In
https://reviews.llvm.org/rL324788 this behaviour was changed to not-clearing
timers on printout, to allow printing timers more than once, but as a result
clients (specifically Swift) that relied on the clear-on-print behaviour to
inhibit duplicate timer printing on shutdown were broken.

Rather than revert that change, this change adds a new API that enables
clients that _want_ to clear all timers to do so explicitly.

Reviewers: george.karpenkov, thegameg

Reviewed By: george.karpenkov

Subscribers: llvm-commits

Differential Revision: https://reviews.llvm.org/D50874

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@339980 91177308-0d34-0410-b5e6-96231b3b80d8