### PR TITLE
Remove unreachable blocks before splitting a coroutine

### DIFF
--- a/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -56,6 +56,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
@@ -1338,7 +1339,26 @@ static void splitCoroutine(Function &F, coro::Shape &Shape,
   llvm_unreachable("bad ABI kind");
 }
 
+namespace {
+  class PrettyStackTraceFunction : public PrettyStackTraceEntry {
+    Function &F;
+  public:
+    PrettyStackTraceFunction(Function &F) : F(F) {}
+    void print(raw_ostream &OS) const override {
+      OS << "While splitting coroutine ";
+      F.printAsOperand(OS, /*print type*/ false, F.getParent());
+      OS << "\n";
+    }
+  };
+}
+
 static void splitCoroutine(Function &F, CallGraph &CG, CallGraphSCC &SCC) {
+  PrettyStackTraceFunction prettyStackTrace(F);
+
+  // The suspend-crossing algorithm in buildCoroutineFrame get tripped
+  // up by uses in unreachable blocks, so remove them as a first pass.
+  removeUnreachableBlocks(F);
+
   coro::Shape Shape(F);
   if (!Shape.CoroBegin)
     return;

--- a/test/Transforms/Coroutines/coro-retcon-unreachable.ll
+++ b/test/Transforms/Coroutines/coro-retcon-unreachable.ll
@@ -1,0 +1,46 @@
+; RUN: opt < %s -coro-early -coro-split -S | FileCheck %s
+target datalayout = "E-p:64:64"
+
+%swift.type = type { i64 }
+%swift.opaque = type opaque
+%T4red215EmptyCollectionV = type opaque
+%TSi = type <{ i64 }>
+
+define hidden swiftcc { i8*, %swift.opaque* } @no_suspends(i8* %buffer, i64 %arg) #1 {
+  %id = call token @llvm.coro.id.retcon.once(i32 32, i32 8, i8* %buffer, i8* bitcast (void (i8*, i1)* @prototype to i8*), i8* bitcast (i8* (i64)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
+  %begin = call i8* @llvm.coro.begin(token %id, i8* null)
+  call void @print(i64 %arg)
+  call void @llvm.trap()
+  unreachable
+
+bb1:
+  call void @print(i64 %arg)
+  call i1 @llvm.coro.end(i8* %begin, i1 false)
+  unreachable
+}
+; CHECK-LABEL: define hidden swiftcc { i8*, %swift.opaque* } @no_suspends(
+; CHECK:         call token @llvm.coro.id.retcon.once
+; CHECK-NEXT:    call void @print(i64 %arg)
+; CHECK-NEXT:    call void @llvm.trap()
+; CHECK-NEXT:    unreachable
+
+declare swiftcc void @prototype(i8* noalias dereferenceable(32), i1)
+declare void @print(i64)
+
+declare noalias i8* @malloc(i64) #5
+declare void @free(i8* nocapture) #5
+
+declare token @llvm.coro.id.retcon.once(i32, i32, i8*, i8*, i8*, i8*) #5
+declare i8* @llvm.coro.begin(token, i8* writeonly) #5
+declare token @llvm.coro.alloca.alloc.i64(i64, i32) #5
+declare i8* @llvm.coro.alloca.get(token) #5
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #6
+declare i1 @llvm.coro.suspend.retcon.i1(...) #5
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #6
+declare void @llvm.coro.alloca.free(token) #5
+declare i1 @llvm.coro.end(i8*, i1) #5
+
+declare void @llvm.trap()
+
+attributes #1 = { noreturn nounwind }
+attributes #5 = { nounwind }


### PR DESCRIPTION
The suspend-crossing algorithm is not correct in the presence of uses that cannot be reached on some successor path from their defs.