### PR TITLE
[DNM] [Support] Remove nonnull attribute from allocator

### DIFF
--- a/include/llvm/Support/Allocator.h
+++ b/include/llvm/Support/Allocator.h
@@ -209,10 +209,13 @@ public:
     Slabs.erase(std::next(Slabs.begin()), Slabs.end());
   }
 
-  /// Allocate space at the specified alignment.
-  LLVM_ATTRIBUTE_RETURNS_NONNULL LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
+  /// Allocate space at the specified alignment. Returns null if 
+  /// \a Size is zero; this does not indicate an error.
+  LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
   Allocate(size_t Size, size_t Alignment) {
-    assert(Alignment > 0 && "0-byte alignnment is not allowed. Use 1 instead.");
+    assert(Alignment > 0 && "0-byte alignment is not allowed. Use 1 instead.");
+    if (Size == 0)
+      return nullptr;
 
     // Keep track of how many bytes we've allocated.
     BytesAllocated += Size;

--- a/unittests/Support/AllocatorTest.cpp
+++ b/unittests/Support/AllocatorTest.cpp
@@ -185,4 +185,15 @@ TEST(AllocatorTest, TestBigAlignment) {
   EXPECT_GT(MockSlabAllocator::GetLastSlabSize(), 4096u);
 }
 
+// Test that Allocate() behaves properly when asked to allocate zero bytes.
+TEST(AllocatorTest, EmptyAllocation) {
+  BumpPtrAllocator Alloc;
+
+  void *a = Alloc.Allocate(0, 1);
+  EXPECT_EQ(a, nullptr);
+  
+  void *b = Alloc.Allocate<int>(0);
+  EXPECT_EQ(b, nullptr);
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
I'm trying to get this merged upstream, but I want to get compiler benchmark numbers from our CI.