### PR TITLE
ARM: handle checking aliases with out-of-bounds GEPs

### DIFF
--- a/lib/Target/ARM/ARMISelLowering.cpp
+++ b/lib/Target/ARM/ARMISelLowering.cpp
@@ -3184,9 +3184,11 @@ static SDValue promoteToConstantPool(const GlobalValue *GV, SelectionDAG &DAG,
 
 bool ARMTargetLowering::isReadOnly(const GlobalValue *GV) const {
   if (const GlobalAlias *GA = dyn_cast<GlobalAlias>(GV))
-    GV = GA->getBaseObject();
-  return (isa<GlobalVariable>(GV) && cast<GlobalVariable>(GV)->isConstant()) ||
-         isa<Function>(GV);
+    if (!(GV = GA->getBaseObject()))
+      return false;
+  if (const auto *V = dyn_cast<GlobalVariable>(GV))
+    return V->isConstant();
+  return isa<Function>(GV);
 }
 
 SDValue ARMTargetLowering::LowerGlobalAddress(SDValue Op,

--- a/test/CodeGen/ARM/readonly-aliases.ll
+++ b/test/CodeGen/ARM/readonly-aliases.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple thumbv7-unknown-linux-android -filetype asm -o - %s | FileCheck %s
+
+@a = protected constant <{ i32, i32 }> <{ i32 0, i32 0 }>
+@b = protected alias i32, getelementptr(i32, i32* getelementptr inbounds (<{ i32, i32 }>, <{ i32, i32 }>* @a, i32 0, i32 1), i32 -1)
+
+declare void @f(i32*)
+
+define void @g() {
+entry:
+  call void @f(i32* @b)
+  ret void
+}
+
+; CHECK-LABEL: g:
+; CHECK: movw [[REGISTER:r[0-9]+]], :lower16:b
+; CHECK: movt [[REGISTER]], :upper16:b
+


### PR DESCRIPTION
A global alias may use indices which are not considered in bounds.  In
such a case, accessing the base object will fail as it only peers
through inbounds accesses.  This pattern is used by the swift compiler
to create references to preceeding members in the type metadata.  This
would cause the code generation to fail when targeting a platform that
used ELF as the object file format.  Be conservative and fail the
read-only check if we run into an alias that we cannot peer through.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@345107 91177308-0d34-0410-b5e6-96231b3b80d8