### PR TITLE
IR: fix documentation markup

### DIFF
--- a/include/llvm/IR/Attributes.h
+++ b/include/llvm/IR/Attributes.h
@@ -466,12 +466,12 @@ public:
     return removeAttributes(C, ArgNo + FirstArgIndex);
   }
 
-  /// \Brief Add the dereferenceable attribute to the attribute set at the given
+  /// \brief Add the dereferenceable attribute to the attribute set at the given
   /// index. Returns a new list because attribute lists are immutable.
   AttributeList addDereferenceableAttr(LLVMContext &C, unsigned Index,
                                        uint64_t Bytes) const;
 
-  /// \Brief Add the dereferenceable attribute to the attribute set at the given
+  /// \brief Add the dereferenceable attribute to the attribute set at the given
   /// arg index. Returns a new list because attribute lists are immutable.
   AttributeList addDereferenceableParamAttr(LLVMContext &C, unsigned ArgNo,
                                             uint64_t Bytes) const {


### PR DESCRIPTION
Use `\brief` instead of `\Brief`.  NFC.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@334627 91177308-0d34-0410-b5e6-96231b3b80d8

Backporting to swift-4.2-branch to silence warning tsunami