### PR TITLE
Relax DIE verification

### DIFF
--- a/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -97,6 +97,9 @@ private:
   /// lies between to valid DIEs.
   std::map<uint64_t, std::set<uint32_t>> ReferenceToDIEOffsets;
   uint32_t NumDebugLineErrors = 0;
+  // Used to relax some checks that do not currently work portably
+  bool IsObjectFile;
+  bool IsMachOObject;
 
   raw_ostream &error() const;
   raw_ostream &warn() const;
@@ -286,8 +289,8 @@ private:
 
 public:
   DWARFVerifier(raw_ostream &S, DWARFContext &D,
-                DIDumpOptions DumpOpts = DIDumpOptions::getForSingleDIE())
-      : OS(S), DCtx(D), DumpOpts(std::move(DumpOpts)) {}
+                DIDumpOptions DumpOpts = DIDumpOptions::getForSingleDIE());
+
   /// Verify the information in any of the following sections, if available:
   /// .debug_abbrev, debug_abbrev.dwo
   ///

--- a/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -379,20 +379,42 @@ unsigned DWARFVerifier::verifyDieRanges(const DWARFDie &Die,
   // Build RI for this DIE and check that ranges within this DIE do not
   // overlap.
   DieRangeInfo RI(Die);
-  for (auto Range : Ranges) {
-    if (!Range.valid()) {
-      ++NumErrors;
-      error() << "Invalid address range " << Range << "\n";
-      continue;
-    }
 
-    // Verify that ranges don't intersect.
-    const auto IntersectingRange = RI.insert(Range);
-    if (IntersectingRange != RI.Ranges.end()) {
-      ++NumErrors;
-      error() << "DIE has overlapping address ranges: " << Range << " and "
-              << *IntersectingRange << "\n";
-      break;
+  // TODO support object files better
+  //
+  // Some object file formats (i.e. non-MachO) support COMDAT.  ELF in
+  // particular does so by placing each function into a section.  The DWARF data
+  // for the function at that point uses a section relative DW_FORM_addrp for
+  // the DW_AT_low_pc and a DW_FORM_data4 for the offset as the DW_AT_high_pc.
+  // In such a case, when the Die is the CU, the ranges will overlap, and we
+  // will flag valid conflicting ranges as invalid.
+  //
+  // For such targets, we should read the ranges from the CU and partition them
+  // by the section id.  The ranges within a particular section should be
+  // disjoint, although the ranges across sections may overlap.  We would map
+  // the child die to the entity that it references and the section with which
+  // it is associated.  The child would then be checked against the range
+  // information for the associated section.
+  //
+  // For now, simply elide the range verification for the CU DIEs if we are
+  // processing an object file.
+
+  if (!IsObjectFile || IsMachOObject || Die.getTag() == DW_TAG_subprogram) {
+    for (auto Range : Ranges) {
+      if (!Range.valid()) {
+        ++NumErrors;
+        error() << "Invalid address range " << Range << "\n";
+        continue;
+      }
+
+      // Verify that ranges don't intersect.
+      const auto IntersectingRange = RI.insert(Range);
+      if (IntersectingRange != RI.Ranges.end()) {
+        ++NumErrors;
+        error() << "DIE has overlapping address ranges: " << Range << " and "
+                << *IntersectingRange << "\n";
+        break;
+      }
     }
   }
 
@@ -718,6 +740,15 @@ void DWARFVerifier::verifyDebugLineRows() {
         PrevAddress = Row.Address;
       ++RowIndex;
     }
+  }
+}
+
+DWARFVerifier::DWARFVerifier(raw_ostream &S, DWARFContext &D,
+                             DIDumpOptions DumpOpts)
+    : OS(S), DCtx(D), DumpOpts(std::move(DumpOpts)) {
+  if (const auto *F = DCtx.getDWARFObj().getFile()) {
+    IsObjectFile = F->isRelocatableObject();
+    IsMachOObject = F->isMachO();
   }
 }
 

--- a/test/tools/llvm-dwarfdump/X86/debug-verify-object.s
+++ b/test/tools/llvm-dwarfdump/X86/debug-verify-object.s
@@ -1,0 +1,57 @@
+# RUN: llvm-mc -filetype obj -o - %s | llvm-dwarfdump --verify -
+
+	.text
+
+	.section	.text.f,"ax",@progbits
+	.globl	f
+	.type	f,@function
+f:
+.Lfunc_begin0:
+	pushq	$32
+	popq	%rax
+	retq
+.Lfunc_end0:
+	.size	f, .Lfunc_end0-f
+
+	.section	.text.g,"ax",@progbits
+	.globl	g
+	.type	g,@function
+g:
+.Lfunc_begin1:
+	pushq   $64
+	popq    %rax
+	retq
+.Lfunc_end1:
+	.size	g, .Lfunc_end1-g
+
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                       # Abbreviation Code
+	.byte	17                      # DW_TAG_compile_unit
+	.byte	0                       # DW_CHILDREN_no
+	.byte	17                      # DW_AT_low_pc
+	.byte	1                       # DW_FORM_addr
+	.byte	85                      # DW_AT_ranges
+	.byte	23                      # DW_FORM_sec_offset
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	0                       # EOM(3)
+
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	20                      # Length of Unit
+	.short	4                       # DWARF version number
+	.long	.debug_abbrev           # Offset Into Abbrev. Section
+	.byte	8                       # Address Size (in bytes)
+	.byte	1                       # Abbrev [1] 0xb:0x1f DW_TAG_compile_unit
+	.quad	0                       # DW_AT_low_pc
+	.long	.Ldebug_ranges0         # DW_AT_ranges
+
+	.section        .debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Lfunc_begin0
+	.quad	.Lfunc_end0
+	.quad	.Lfunc_begin1
+	.quad	.Lfunc_end1
+	.quad	0
+	.quad	0
+

--- a/test/tools/llvm-dwarfdump/X86/debug-verify-object.s
+++ b/test/tools/llvm-dwarfdump/X86/debug-verify-object.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -filetype obj -o - %s | llvm-dwarfdump --verify -
+# RUN: llvm-mc -triple x86_64-unknown-linux-gnu -filetype obj -o - %s | llvm-dwarfdump --verify -
 
 	.text
 


### PR DESCRIPTION
This relaxes the DWARF verifier for object files.  In particular, this is important for ELF where COMDATs are created by means of function sections.  Each section is independent and the `DW_AT_low_pc` is a section relative address.  The linker will coalesce the sections into the text segment and then update the debug info.  The current approach of verifying the contents of DW_AT_ranges of the CU does not work as a result as the overlapping address is totally valid.  The bug was uncovered while trying to fix the IRGen for swift on ELF and COFF targets.  Without this change, in order to fix a size regression and a complete failure for building code for Windows targets, we would need to disable tests that verify the generated debug information on object files which would open the door for introducing debug information QoI regressions.

CC: @adrian-prantl @JDevlieghere @bob-wilson @tkremenek 