### PR TITLE
DWARFVerifier: make the verifier more comprehensive for objects

### DIFF
--- a/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -399,7 +399,7 @@ unsigned DWARFVerifier::verifyDieRanges(const DWARFDie &Die,
   // For now, simply elide the range verification for the CU DIEs if we are
   // processing an object file.
 
-  if (!IsObjectFile || IsMachOObject || Die.getTag() == DW_TAG_subprogram) {
+  if (!IsObjectFile || IsMachOObject || Die.getTag() != DW_TAG_compile_unit) {
     for (auto Range : Ranges) {
       if (!Range.valid()) {
         ++NumErrors;


### PR DESCRIPTION
Make the code do what was mentioned in the comment: only skip the CU types.
This enables the lexical blocks to be verified as well.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@345675 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 1c6bfcc50c346e44d3a1c1a9b0e6da159e503362)