### PR TITLE
Revert "Re-apply r346985: [ADT] Drop llvm::Optional clang-specific optimization for trivially copyable types"

### DIFF
--- a/include/llvm/ADT/Optional.h
+++ b/include/llvm/ADT/Optional.h
@@ -108,6 +108,24 @@ template <typename T, bool IsPodLike> struct OptionalStorage {
   }
 };
 
+#if !defined(__GNUC__) || defined(__clang__) // GCC up to GCC7 miscompiles this.
+/// Storage for trivially copyable types only.
+template <typename T> struct OptionalStorage<T, true> {
+  AlignedCharArrayUnion<T> storage;
+  bool hasVal = false;
+
+  OptionalStorage() = default;
+
+  OptionalStorage(const T &y) : hasVal(true) { new (storage.buffer) T(y); }
+  OptionalStorage &operator=(const T &y) {
+    *reinterpret_cast<T *>(storage.buffer) = y;
+    hasVal = true;
+    return *this;
+  }
+
+  void reset() { hasVal = false; }
+};
+#endif
 } // namespace optional_detail
 
 template <typename T> class Optional {

--- a/unittests/ADT/OptionalTest.cpp
+++ b/unittests/ADT/OptionalTest.cpp
@@ -518,5 +518,13 @@ TEST_F(OptionalTest, OperatorGreaterEqual) {
   CheckRelation<GreaterEqual>(InequalityLhs, InequalityRhs, !IsLess);
 }
 
+#if __has_feature(is_trivially_copyable) && defined(_LIBCPP_VERSION)
+static_assert(std::is_trivially_copyable<Optional<int>>::value,
+              "Should be trivially copyable");
+static_assert(
+    !std::is_trivially_copyable<Optional<NonDefaultConstructible>>::value,
+    "Shouldn't be trivially copyable");
+#endif
+
 } // end anonymous namespace
 


### PR DESCRIPTION
This reverts commit 83343ed6a1b102f1175506d36ba7d3bc88dbbbed.

master-next doesn't build otherwise (rdar://problem/46128545)