### PR TITLE
Support: use std::is_trivially_copyable on MSVC

### DIFF
--- a/include/llvm/Support/type_traits.h
+++ b/include/llvm/Support/type_traits.h
@@ -30,9 +30,10 @@ namespace llvm {
 template <typename T>
 struct isPodLike {
   // std::is_trivially_copyable is available in libc++ with clang, libstdc++
-  // that comes with GCC 5.
+  // that comes with GCC 5.  MSVC 2015 and newer also have
+  // std::is_trivially_copyable.
 #if (__has_feature(is_trivially_copyable) && defined(_LIBCPP_VERSION)) ||      \
-    (defined(__GNUC__) && __GNUC__ >= 5)
+    (defined(__GNUC__) && __GNUC__ >= 5) || defined(_MSC_VER)
   // If the compiler supports the is_trivially_copyable trait use it, as it
   // matches the definition of isPodLike closely.
   static const bool value = std::is_trivially_copyable<T>::value;


### PR DESCRIPTION
MSVC 2015 and newer have std::is_trivially_copyable available for use.
We should prefer that over the std::is_class to get this check be
correct.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@348042 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 39cd6300aab3f78d645b33615b7c73633ddc8260)