### PR TITLE
Change llvm call once check for building Swift for PowerPC(ppc64le)

### DIFF
--- a/include/llvm/Support/Threading.h
+++ b/include/llvm/Support/Threading.h
@@ -27,7 +27,7 @@
 #define LLVM_THREADING_USE_STD_CALL_ONCE 1
 #elif defined(LLVM_ON_UNIX) &&                                                 \
     (defined(_LIBCPP_VERSION) ||                                               \
-     !(defined(__NetBSD__) || defined(__OpenBSD__) || defined(__ppc__)))
+     !(defined(__NetBSD__) || defined(__OpenBSD__) || defined(__ppc__)) || (defined(__PPC__) && defined(__LITTLE_ENDIAN__)))
 // std::call_once from libc++ is used on all Unix platforms. Other
 // implementations like libstdc++ are known to have problems on NetBSD,
 // OpenBSD and PowerPC.


### PR DESCRIPTION
Change llvm call once check for building Swift for PowerPC(ppc64le). These changes are required to resolve the call_once related errors seen while building the Swift toolchain on PowerPC64LE.