### PR TITLE
In llvm.asan.globals, allow entries to be non-GlobalVariable and skip over them

### DIFF
--- a/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -436,8 +436,11 @@ public:
     for (auto MDN : Globals->operands()) {
       // Metadata node contains the global and the fields of "Entry".
       assert(MDN->getNumOperands() == 5);
-      auto *GV = mdconst::extract_or_null<GlobalVariable>(MDN->getOperand(0));
+      auto *V = mdconst::extract_or_null<Constant>(MDN->getOperand(0));
       // The optimizer may optimize away a global entirely.
+      if (!V) continue;
+      auto *StrippedV = V->stripPointerCasts();
+      auto *GV = dyn_cast<GlobalVariable>(StrippedV);
       if (!GV) continue;
       // We can already have an entry for GV if it was merged with another
       // global.

--- a/test/Instrumentation/AddressSanitizer/global_metadata_bitcasts.ll
+++ b/test/Instrumentation/AddressSanitizer/global_metadata_bitcasts.ll
@@ -1,0 +1,13 @@
+; Test that the compiler doesn't crash when the llvm.asan.globals containts
+; an entry that points to a BitCast instruction.
+
+; RUN: opt < %s -asan -asan-module -asan-globals-live-support=1 -S
+
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.11.0"
+
+@g = global [1 x i32] zeroinitializer, align 4
+
+!llvm.asan.globals = !{!0, !1}
+!0 = !{[1 x i32]* @g, null, !"name", i1 false, i1 false}
+!1 = !{i8* bitcast ([1 x i32]* @g to i8*), null, !"name", i1 false, i1 false}


### PR DESCRIPTION
Swift from master currently crashes when building even very simple programs with -O -whole-module-optimization -sanitize=address. The actual crash happens in the AddressSanitizer instrumentation pass because it finds entries inside the llvm.asan.globals list that are not GlobalVariable objects. In short, what happens is that when IRGen emits type descriptors, we add them to the llvm.asan.globals list to avoid instrumenting them, but in WMO, we emit lazy type descriptors and use forward declarations and when those are later replaced with an actual definition, we use replaceAllUsesWith to replace them with a BitCast object. There are valid reasons why we need the BitCast when replacing the type descriptor, so we should instead allow them in the llvm.asan.globals list.