### PR TITLE
<rdar://problem/47176262> FileCheck/match-full-lines.txt test failing when FILECHECK_DUMP_INPUT_ON_FAILURE is set in environment

### DIFF
--- a/test/FileCheck/lit.local.cfg
+++ b/test/FileCheck/lit.local.cfg
@@ -1,0 +1,13 @@
+# Unset environment variables that the FileCheck tests
+# expect not to be set.
+file_check_expected_unset_vars = [
+  'FILECHECK_DUMP_INPUT_ON_FAILURE',
+  'FILECHECK_OPTS',
+]
+
+for env_var in file_check_expected_unset_vars:
+  if env_var in config.environment:
+    lit_config.note('Removing {} from environment for FileCheck tests'.format(
+      env_var)
+    )
+    config.environment.pop(env_var)

--- a/utils/lit/tests/shtest-run-at-line.py
+++ b/utils/lit/tests/shtest-run-at-line.py
@@ -1,7 +1,7 @@
 # Check that -vv makes the line number of the failing RUN command clear.
 # (-v is actually sufficient in the case of the internal shell.)
 #
-# RUN: not %{lit} -j 1 -vv %{inputs}/shtest-run-at-line > %t.out
+# RUN: env -u FILECHECK_OPTS not %{lit} -j 1 -vv %{inputs}/shtest-run-at-line > %t.out
 # RUN: FileCheck --input-file %t.out %s
 #
 # END.


### PR DESCRIPTION
Cherry pick from upstream LLVM.