### PR TITLE
[ADT] Fix a typo in isOSVersionLT that breaks the Micro version check

### DIFF
--- a/include/llvm/ADT/Triple.h
+++ b/include/llvm/ADT/Triple.h
@@ -415,7 +415,7 @@ public:
     if (LHS[1] != Minor)
       return LHS[1] < Minor;
     if (LHS[2] != Micro)
-      return LHS[1] < Micro;
+      return LHS[2] < Micro;
 
     return false;
   }


### PR DESCRIPTION
The original commit of this function (r129800 in 2011) had a typo where
part of the "Micro" version check was actually comparing against the "Minor"
version number.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@352776 91177308-0d34-0410-b5e6-96231b3b80d8

rdar://problem/47643166