### PR TITLE
Support: enable backtraces on Windows

### DIFF
--- a/lib/Support/PrettyStackTrace.cpp
+++ b/lib/Support/PrettyStackTrace.cpp
@@ -34,7 +34,7 @@ using namespace llvm;
 // If backtrace support is not enabled, compile out support for pretty stack
 // traces.  This has the secondary effect of not requiring thread local storage
 // when backtrace support is disabled.
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
 
 // We need a thread local pointer to manage the stack of our stack trace
 // objects, but we *really* cannot tolerate destructors running and do not want
@@ -128,11 +128,10 @@ static void CrashHandler(void *) {
 #endif
 }
 
-// defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
-#endif
+#endif // ENABLE_BACKTRACES
 
 PrettyStackTraceEntry::PrettyStackTraceEntry() {
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
   // Link ourselves.
   NextEntry = PrettyStackTraceHead;
   PrettyStackTraceHead = this;
@@ -140,7 +139,7 @@ PrettyStackTraceEntry::PrettyStackTraceEntry() {
 }
 
 PrettyStackTraceEntry::~PrettyStackTraceEntry() {
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
   assert(PrettyStackTraceHead == this &&
          "Pretty stack trace entry destruction is out of order");
   PrettyStackTraceHead = NextEntry;
@@ -175,7 +174,7 @@ void PrettyStackTraceProgram::print(raw_ostream &OS) const {
   OS << '\n';
 }
 
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
 static bool RegisterCrashPrinter() {
   sys::AddSignalHandler(CrashHandler, nullptr);
   return false;
@@ -183,7 +182,7 @@ static bool RegisterCrashPrinter() {
 #endif
 
 void llvm::EnablePrettyStackTrace() {
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
   // The first time this is called, we register the crash printer.
   static bool HandlerRegistered = RegisterCrashPrinter();
   (void)HandlerRegistered;
@@ -191,7 +190,7 @@ void llvm::EnablePrettyStackTrace() {
 }
 
 const void *llvm::SavePrettyStackState() {
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
   return PrettyStackTraceHead;
 #else
   return nullptr;
@@ -199,7 +198,7 @@ const void *llvm::SavePrettyStackState() {
 }
 
 void llvm::RestorePrettyStackState(const void *Top) {
-#if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES
+#if ENABLE_BACKTRACES
   PrettyStackTraceHead =
       static_cast<PrettyStackTraceEntry *>(const_cast<void *>(Top));
 #endif


### PR DESCRIPTION
Some platforms, e.g. Windows, support backtraces but don't have
BACKTRACE. Checking for BACKTRACE prevents Windows from having
backtraces.

Patch by Jason Mittertreiner!

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@354951 91177308-0d34-0410-b5e6-96231b3b80d8
--------------------------------

Cherry pick from upstream. This gives us nice stack traces with program arguments on Windows
```
S:\b\swift> &"S:\\b\\swift\\bin\\swiftc.exe" -frontend -debug-assert-immediately test.swift   
Assertion failed: 0 && "This is an assertion!", file S:\swift\lib\Frontend\ArgsToFrontendOptionsConverter.cpp, line 41                                                                      
Stack dump:                                                                                   
0.      Program arguments: S:\b\swift\bin\swiftc.exe -frontend -debug-assert-immediately test.swift                                                                                         
 #0 0x00007ff78504fcc5 HandleAbort s:\llvm\lib\support\windows\signals.inc:409:0              
 #1 0x00007ffb79acd4cb (C:\windows\System32\ucrtbase.dll+0x6d4cb)                             
 #2 0x00007ffb79ace561 (C:\windows\System32\ucrtbase.dll+0x6e561)                             
 #3 0x00007ffb79ad0316 (C:\windows\System32\ucrtbase.dll+0x70316)                             
 #4 0x00007ffb79ad0211 (C:\windows\System32\ucrtbase.dll+0x70211)                             
 #5 0x00007ffb79ad054f (C:\windows\System32\ucrtbase.dll+0x7054f)                             
 #6 0x00007ff7814785ef swift::ArgsToFrontendOptionsConverter::handleDebugCrashGroupArguments(void) S:\swift\lib\Frontend\ArgsToFrontendOptionsConverter.cpp:181:0                           
 #7 0x00007ff78147708f swift::ArgsToFrontendOptionsConverter::convert(class llvm::SmallVectorImpl<class std::unique_ptr<class llvm::MemoryBuffer,struct std::default_delete<class llvm::MemoryBuffer> > > *) S:\swift\lib\Frontend\ArgsToFrontendOptionsConverter.cpp:54:0                
 #8 0x00007ff781445a45 ParseFrontendArgs S:\swift\lib\Frontend\CompilerInvocation.cpp:95:0    
 #9 0x00007ff7814456cc swift::CompilerInvocation::parseArgs(class llvm::ArrayRef<char const *>,class swift::DiagnosticEngine &,class llvm::SmallVectorImpl<class std::unique_ptr<class llvm::MemoryBuffer,struct std::default_delete<class llvm::MemoryBuffer> > > *,class llvm::StringRef) S:\swift\lib\Frontend\CompilerInvocation.cpp:1227:0                                         
#10 0x00007ff7811cfc18 swift::performFrontend(class llvm::ArrayRef<char const *>,char const *,void *,class swift::FrontendObserver *) S:\swift\lib\FrontendTool\FrontendTool.cpp:1676:0     
#11 0x00007ff781152739 run_driver S:\swift\tools\driver\driver.cpp:125:0                      
#12 0x00007ff781151b7a main S:\swift\tools\driver\driver.cpp:276:0                            
#13 0x00007ff7850c899c __scrt_common_main_seh d:\agent\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288:0                                                                 
#14 0x00007ffb7bfe3dc4 (C:\windows\System32\KERNEL32.DLL+0x13dc4)                             
#15 0x00007ffb7cff3691 (C:\windows\SYSTEM32\ntdll.dll+0x73691)    
```