### PR TITLE
Cherry-pick "Add Swift enumerator value for CodeView::SourceLanguage" from llvm.org/master

### DIFF
--- a/include/llvm/DebugInfo/CodeView/CodeView.h
+++ b/include/llvm/DebugInfo/CodeView/CodeView.h
@@ -160,9 +160,10 @@ enum SourceLanguage : uint8_t {
   MSIL = 0x0f,
   HLSL = 0x10,
 
-  /// The DMD compiler emits 'D' for the CV source language. Microsoft doesn't
-  /// have an enumerator for it yet.
+  /// The DMD & Swift compilers emit 'D' and 'S', respectively, for the CV
+  /// source language. Microsoft does not have enumerators for them yet.
   D = 'D',
+  Swift = 'S',
 };
 
 /// These values correspond to the CV_call_e enumeration, and are documented

--- a/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -700,6 +700,8 @@ static SourceLanguage MapDWLangToCVLang(unsigned DWLang) {
     return SourceLanguage::Java;
   case dwarf::DW_LANG_D:
     return SourceLanguage::D;
+  case dwarf::DW_LANG_Swift:
+    return SourceLanguage::Swift;
   default:
     // There's no CodeView representation for this language, and CV doesn't
     // have an "unknown" option for the language field, so we'll use MASM,

--- a/lib/DebugInfo/CodeView/EnumTables.cpp
+++ b/lib/DebugInfo/CodeView/EnumTables.cpp
@@ -87,6 +87,7 @@ static const EnumEntry<codeview::SourceLanguage> SourceLanguages[] = {
     CV_ENUM_ENT(SourceLanguage, ILAsm),   CV_ENUM_ENT(SourceLanguage, Java),
     CV_ENUM_ENT(SourceLanguage, JScript), CV_ENUM_ENT(SourceLanguage, MSIL),
     CV_ENUM_ENT(SourceLanguage, HLSL),    CV_ENUM_ENT(SourceLanguage, D),
+    CV_ENUM_ENT(SourceLanguage, Swift),
 };
 
 static const EnumEntry<uint32_t> CompileSym2FlagNames[] = {

--- a/lib/DebugInfo/PDB/PDBExtras.cpp
+++ b/lib/DebugInfo/PDB/PDBExtras.cpp
@@ -193,6 +193,7 @@ raw_ostream &llvm::pdb::operator<<(raw_ostream &OS, const PDB_Lang &Lang) {
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, MSIL, OS)
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, HLSL, OS)
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, D, OS)
+    CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, Swift, OS)
   }
   return OS;
 }

--- a/lib/DebugInfo/PDB/PDBSymbolCompiland.cpp
+++ b/lib/DebugInfo/PDB/PDBSymbolCompiland.cpp
@@ -91,16 +91,16 @@ std::string PDBSymbolCompiland::getSourceFileFullPath() const {
   PDB_Lang Lang = Details ? Details->getLanguage() : PDB_Lang::Cpp;
   auto SrcFiles = Session.getSourceFilesForCompiland(*this);
   if (SrcFiles) {
-    bool LangC = (Lang == PDB_Lang::Cpp || Lang == PDB_Lang::C);
     while (auto File = SrcFiles->getNext()) {
       std::string FileName = File->getFileName();
       auto file_extension = sys::path::extension(FileName);
       if (StringSwitch<bool>(file_extension.lower())
-              .Case(".cpp", LangC)
-              .Case(".c", LangC)
-              .Case(".cc", LangC)
-              .Case(".cxx", LangC)
+              .Case(".cpp", Lang == PDB_Lang::Cpp)
+              .Case(".cc", Lang == PDB_Lang::Cpp)
+              .Case(".cxx", Lang == PDB_Lang::Cpp)
+              .Case(".c", Lang == PDB_Lang::C)
               .Case(".asm", Lang == PDB_Lang::Masm)
+              .Case(".swift", Lang == PDB_Lang::Swift)
               .Default(false))
         return File->getFileName();
     }

--- a/test/DebugInfo/COFF/swift.ll
+++ b/test/DebugInfo/COFF/swift.ll
@@ -1,0 +1,42 @@
+; RUN: llc < %s | FileCheck %s --check-prefix=ASM
+; RUN: llc -filetype=obj < %s | llvm-readobj -codeview | FileCheck %s --check-prefix=OBJ
+
+; ASM:      .short  4412                    # Record kind: S_COMPILE3
+; ASM-NEXT: .long   83                      # Flags and language
+; ASM-NEXT: .short  208                     # CPUType
+
+; OBJ-LABEL: Compile3Sym {
+; OBJ-NEXT:    Kind: S_COMPILE3 (0x113C)
+; OBJ-NEXT:    Language: Swift (0x53)
+; OBJ-NEXT:    Flags [ (0x0)
+; OBJ-NEXT:    ]
+; OBJ-NEXT:    Machine: X64 (0xD0)
+; OBJ-NEXT:    FrontendVersion: {{[0-9.]*}}
+; OBJ-NEXT:    BackendVersion: {{[0-9.]*}}
+; OBJ-NEXT:    VersionName: Apple Swift version 5.0 (swiftlang-1001.0.45.7 clang-1001.0.37.7)
+; OBJ-NEXT:  }
+
+
+; ModuleID = 't.c'
+source_filename = "t.swift"
+target datalayout = "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc19.0.24215"
+
+define void @f() !dbg !8 {
+entry:
+  ret void, !dbg !11
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !1, producer: "Apple Swift version 5.0 (swiftlang-1001.0.45.7 clang-1001.0.37.7)", isOptimized: false, runtimeVersion: 5, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "t.d", directory: "asdf")
+!2 = !{}
+!3 = !{i32 2, !"CodeView", i32 1}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"Swift Version", i32 6}
+!8 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !9, isLocal: false, isDefinition: true, scopeLine: 1, isOptimized: false, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{null}
+!11 = !DILocation(line: 1, column: 11, scope: !8)

--- a/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
+++ b/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
@@ -207,6 +207,7 @@ static std::string formatSourceLanguage(SourceLanguage Lang) {
     RETURN_CASE(SourceLanguage, MSIL, "msil");
     RETURN_CASE(SourceLanguage, HLSL, "hlsl");
     RETURN_CASE(SourceLanguage, D, "d");
+    RETURN_CASE(SourceLanguage, Swift, "swift");
   }
   return formatUnknownEnum(Lang);
 }


### PR DESCRIPTION
Summary:
Swift now generates PDBs for debugging on Windows. llvm and lldb
need a language enumerator value too properly handle the output
emitted by swiftc.

Subscribers: jdoerfert, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D59231

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@355882 91177308-0d34-0410-b5e6-96231b3b80d8