### PR TITLE
Support: use internal `call_once` on PPC64le

### DIFF
--- a/include/llvm/Support/Threading.h
+++ b/include/llvm/Support/Threading.h
@@ -33,6 +33,9 @@
 // implementations like libstdc++ are known to have problems on NetBSD,
 // OpenBSD and PowerPC.
 #define LLVM_THREADING_USE_STD_CALL_ONCE 1
+#elif defined(LLVM_ON_UNIX) &&                                                 \
+    ((defined(__ppc__) || defined(__PPC__)) && defined(__LITTLE_ENDIAN__))
+#define LLVM_THREADING_USE_STD_CALL_ONCE 1
 #else
 #define LLVM_THREADING_USE_STD_CALL_ONCE 0
 #endif


### PR DESCRIPTION
Always use the internal `call_once` for PPC64le.  This is needed to
support the Swift toolchain on PPC64le.

Patch by Sarvesh Tamba!

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@354045 91177308-0d34-0410-b5e6-96231b3b80d8