### PR TITLE
[PowerPC] Fix wrong ElemSIze when calling isConsecutiveLS()

### DIFF
--- a/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -12064,7 +12064,7 @@ static SDValue combineBVOfConsecutiveLoads(SDNode *N, SelectionDAG &DAG) {
   SDLoc dl(N);
   bool InputsAreConsecutiveLoads = true;
   bool InputsAreReverseConsecutive = true;
-  unsigned ElemSize = N->getValueType(0).getScalarSizeInBits() / 8;
+  unsigned ElemSize = N->getValueType(0).getScalarType().getStoreSize();
   SDValue FirstInput = N->getOperand(0);
   bool IsRoundOfExtLoad = false;
 

--- a/test/CodeGen/PowerPC/pr41177.ll
+++ b/test/CodeGen/PowerPC/pr41177.ll
@@ -1,0 +1,12 @@
+; RUN: llc -verify-machineinstrs -mcpu=pwr9 -mtriple=powerpc64le-unknown-linux-gnu < %s 
+; REQUIRES: asserts
+
+define protected swiftcc void @"$s22LanguageServerProtocol13HoverResponseV8contents5rangeAcA13MarkupContentV_SnyAA8PositionVGSgtcfC"() {
+  %1 = load <2 x i64>, <2 x i64>* undef, align 16
+  %2 = load i1, i1* undef, align 8
+  %3 = insertelement <2 x i1> undef, i1 %2, i32 0
+  %4 = shufflevector <2 x i1> %3, <2 x i1> undef, <2 x i32> zeroinitializer
+  %5 = select <2 x i1> %4, <2 x i64> zeroinitializer, <2 x i64> %1
+  store <2 x i64> %5, <2 x i64>* undef, align 8
+  ret void
+}


### PR DESCRIPTION
Summary:
This issue from the bugzilla: https://bugs.llvm.org/show_bug.cgi?id=41177

When the two operands for BUILD_VECTOR are same, we will get assert error.
llvm::SDValue combineBVOfConsecutiveLoads(llvm::SDNode*, llvm::SelectionDAG&):
Assertion `!(InputsAreConsecutiveLoads && InputsAreReverseConsecutive) &&
"The loads cannot be both consecutive and reverse consecutive."' failed.

This error caused by the wrong ElemSIze when calling isConsecutiveLS(). We
should use `getScalarType().getStoreSize();` to get the ElemSize instread of
 `getScalarSizeInBits() / 8`.

Reviewed By: jsji

Differential Revision: https://reviews.llvm.org/D60811


git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@358644 91177308-0d34-0410-b5e6-96231b3b80d8