### PR TITLE
Coroutines: adjust for SVN r358739

### DIFF
--- a/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1547,10 +1547,12 @@ static void replacePrepare(CallInst *Prepare, CallGraph &CG) {
     // If so, we'll need to update the call graph.
     if (PrepareUserNode) {
       for (auto &Use : Cast->uses()) {
-        auto CS = CallSite(Use.getUser());
-        if (!CS || !CS.isCallee(&Use)) continue;
-        PrepareUserNode->removeCallEdgeFor(CS);
-        PrepareUserNode->addCalledFunction(CS, FnNode);
+        if (auto *CB = dyn_cast<CallBase>(Use.getUser())) {
+          if (!CB->isCallee(&Use))
+            continue;
+          PrepareUserNode->removeCallEdgeFor(*CB);
+          PrepareUserNode->addCalledFunction(CB, FnNode);
+        }
       }
     }
 


### PR DESCRIPTION
CallSite has been removed in favour of CallBase.  Adjust the coroutine split to
account for that.