### PR TITLE
WIP: [Swift+WASM] patches to support compiling Swift to WebAssembly

### DIFF
--- a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1682,6 +1682,10 @@ static SectionKind getWasmKindForNamedSection(StringRef Name, SectionKind K) {
   if (K.isText())
     return SectionKind::getText();
 
+  // Clang precompiled header data isn't needed at runtime; use custom section
+  if (Name == "__clangast")
+    return SectionKind::getMetadata();
+
   // Otherwise, ignore whatever section type the generic impl detected and use
   // a plain data section.
   return SectionKind::getData();

--- a/lib/MC/MCWasmStreamer.cpp
+++ b/lib/MC/MCWasmStreamer.cpp
@@ -88,6 +88,7 @@ bool MCWasmStreamer::EmitSymbolAttribute(MCSymbol *S, MCSymbolAttr Attribute) {
   getAssembler().registerSymbol(*Symbol);
 
   switch (Attribute) {
+  case MCSA_Cold:
   case MCSA_LazyReference:
   case MCSA_Reference:
   case MCSA_SymbolResolver:

--- a/lib/MC/MCWasmStreamer.cpp
+++ b/lib/MC/MCWasmStreamer.cpp
@@ -88,7 +88,6 @@ bool MCWasmStreamer::EmitSymbolAttribute(MCSymbol *S, MCSymbolAttr Attribute) {
   getAssembler().registerSymbol(*Symbol);
 
   switch (Attribute) {
-  case MCSA_Cold:
   case MCSA_LazyReference:
   case MCSA_Reference:
   case MCSA_SymbolResolver:

--- a/lib/MC/WasmObjectWriter.cpp
+++ b/lib/MC/WasmObjectWriter.cpp
@@ -496,6 +496,10 @@ void WasmObjectWriter::recordRelocation(MCAssembler &Asm,
     const auto *Inner = dyn_cast<MCSymbolRefExpr>(Expr);
     if (Inner && Inner->getKind() == MCSymbolRefExpr::VK_WEAKREF)
       llvm_unreachable("weakref used in reloc not yet implemented");
+    if (!Inner) {
+      fprintf(stderr, "weak check failed to get an inner:\n");
+      Expr->dump();
+    }
   }
 
   // Put any constant offset in an addend. Offsets can be negative, and

--- a/lib/MC/WasmObjectWriter.cpp
+++ b/lib/MC/WasmObjectWriter.cpp
@@ -496,10 +496,6 @@ void WasmObjectWriter::recordRelocation(MCAssembler &Asm,
     const auto *Inner = dyn_cast<MCSymbolRefExpr>(Expr);
     if (Inner && Inner->getKind() == MCSymbolRefExpr::VK_WEAKREF)
       llvm_unreachable("weakref used in reloc not yet implemented");
-    if (!Inner) {
-      fprintf(stderr, "weak check failed to get an inner:\n");
-      Expr->dump();
-    }
   }
 
   // Put any constant offset in an addend. Offsets can be negative, and

--- a/lib/MC/WasmObjectWriter.cpp
+++ b/lib/MC/WasmObjectWriter.cpp
@@ -1128,6 +1128,10 @@ static bool isInSymtab(const MCSymbolWasm &Sym) {
   if (Sym.isSection())
     return false;
 
+  // Clang's precompiled headers are in a separate custom section
+  if (Sym.getName() == "__clang_ast")
+    return false;
+
   return true;
 }
 

--- a/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -623,7 +623,8 @@ static bool callingConvSupported(CallingConv::ID CallConv) {
          CallConv == CallingConv::Cold ||
          CallConv == CallingConv::PreserveMost ||
          CallConv == CallingConv::PreserveAll ||
-         CallConv == CallingConv::CXX_FAST_TLS;
+         CallConv == CallingConv::CXX_FAST_TLS ||
+         CallConv == CallingConv::Swift;
 }
 
 SDValue


### PR DESCRIPTION
These are the LLVM changes required to cross-compile Swift programs to WebAssembly.

List of changes:
- support -gmodules (debugging information in precompiled headers), used by Clang when compiling stdlib
- enable Swift calling convention for webassembly
- Support alias symbols with offsets
- cherry-pick wasm linking info v2 patch from LLVM master:

See https://github.com/apple/swift/pull/24684 for more information.

We're planning to upstream the required patches to upstream LLVM.
