### PR TITLE
[CMake] Enable '-index-store-path' compiler option on a Debug build, if the compiler supports it and for non-IDE generators

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -669,6 +669,17 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)
   append("-w" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
+# Enable '-index-store-path' on a Debug build, if the compiler supports it and for non-IDE generators.
+set(LLVM_DISABLE_INDEX_STORE OFF CACHE BOOL "Disable '-index-store-path' flag" FORCE)
+if (NOT LLVM_DISABLE_INDEX_STORE AND NOT XCODE AND NOT MSVC_IDE AND uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  set(INDEX_DATA_STORE_PATH "${PROJECT_BINARY_DIR}/IndexStore" CACHE STRING "Index store path" FORCE)
+
+  check_c_compiler_flag("-Werror -index-store-path \"${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore\"" "C_SUPPORTS_INDEX_STORE")
+  append_if("C_SUPPORTS_INDEX_STORE" "-index-store-path \"${INDEX_DATA_STORE_PATH}\"" CMAKE_C_FLAGS)
+  check_cxx_compiler_flag("-Werror -index-store-path \"${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore\"" "CXX_SUPPORTS_INDEX_STORE")
+  append_if("CXX_SUPPORTS_INDEX_STORE" "-index-store-path \"${INDEX_DATA_STORE_PATH}\"" CMAKE_CXX_FLAGS)
+endif()
+
 macro(append_common_sanitizer_flags)
   if (NOT MSVC)
     # Append -fno-omit-frame-pointer and turn on debug info to get better


### PR DESCRIPTION
It can also be explicitely disabled via `LLVM_DISABLE_INDEX_STORE`.