### PR TITLE
[dsymutil] Support more than 4 architectures

### DIFF
--- a/tools/dsymutil/MachOUtils.cpp
+++ b/tools/dsymutil/MachOUtils.cpp
@@ -36,7 +36,7 @@ llvm::Error ArchAndFile::createTempFile() {
   if (!T)
     return T.takeError();
 
-  File = llvm::Optional<sys::fs::TempFile>(std::move(*T));
+  File = llvm::make_unique<sys::fs::TempFile>(std::move(*T));
   return Error::success();
 }
 

--- a/tools/dsymutil/MachOUtils.h
+++ b/tools/dsymutil/MachOUtils.h
@@ -27,13 +27,14 @@ namespace MachOUtils {
 struct ArchAndFile {
   std::string Arch;
   // Optional because TempFile has no default constructor.
-  Optional<llvm::sys::fs::TempFile> File;
+  std::unique_ptr<llvm::sys::fs::TempFile> File;
 
   llvm::Error createTempFile();
   llvm::StringRef path() const;
 
   ArchAndFile(StringRef Arch) : Arch(Arch) {}
   ArchAndFile(ArchAndFile &&A) = default;
+  ArchAndFile &operator=(ArchAndFile &&A) = default;
   ~ArchAndFile();
 };
 


### PR DESCRIPTION
When running dsymutil on a fat binary, we use temporary files in a small
vector of size four. When processing more than 4 architectures, this
resulted in a user-after-move, because the temporary files got moved to
the heap. Instead of storing an optional temp file, we now use a unique
pointer, so the location of the actual temp file doesn't change.

We could test this by checking in 5 binaries for 5 different
architectures, but this seems wasteful, especially since the number of
elements in the small vector is arbitrary.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@362621 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e2172b40a8a7412aa81bc811484266f8b827a6ce)