### PR TITLE
MC: correct the emission of weak aliases in COFF

### DIFF
--- a/lib/MC/WinCOFFObjectWriter.cpp
+++ b/lib/MC/WinCOFFObjectWriter.cpp
@@ -388,7 +388,7 @@ void WinCOFFObjectWriter::DefineSymbol(const MCSymbol &MCSym,
     Sym->Aux[0].AuxType = ATWeakExternal;
     Sym->Aux[0].Aux.WeakExternal.TagIndex = 0;
     Sym->Aux[0].Aux.WeakExternal.Characteristics =
-        COFF::IMAGE_WEAK_EXTERN_SEARCH_LIBRARY;
+        COFF::IMAGE_WEAK_EXTERN_SEARCH_ALIAS;
   } else {
     if (!Base)
       Sym->Data.SectionNumber = COFF::IMAGE_SYM_ABSOLUTE;

--- a/test/MC/COFF/alias.s
+++ b/test/MC/COFF/alias.s
@@ -91,7 +91,7 @@ weak_aliased_to_external = external2
 // CHECK-NEXT:     AuxSymbolCount: 1
 // CHECK-NEXT:     AuxWeakExternal {
 // CHECK-NEXT:       Linked: external2
-// CHECK-NEXT:       Search: Library (0x2)
+// CHECK-NEXT:       Search: Alias (0x3)
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   Symbol {

--- a/test/MC/COFF/weak-alias-local.s
+++ b/test/MC/COFF/weak-alias-local.s
@@ -29,7 +29,7 @@ a=b
 // CHECK-NEXT:   AuxSymbolCount: 1
 // CHECK-NEXT:   AuxWeakExternal {
 // CHECK-NEXT:     Linked: .weak.a.default (9)
-// CHECK-NEXT:     Search: Library (0x2)
+// CHECK-NEXT:     Search: Alias (0x3)
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: Symbol {

--- a/test/MC/COFF/weak-val.s
+++ b/test/MC/COFF/weak-val.s
@@ -19,7 +19,7 @@ b:
 // CHECK-NEXT:   AuxSymbolCount: 1
 // CHECK-NEXT:   AuxWeakExternal {
 // CHECK-NEXT:     Linked: .weak.b.default (8)
-// CHECK-NEXT:     Search: Library (0x2)
+// CHECK-NEXT:     Search: Alias (0x3)
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: Symbol {

--- a/test/MC/COFF/weak.s
+++ b/test/MC/COFF/weak.s
@@ -54,7 +54,7 @@ LBB0_2:                                 # %return
 // CHECK-NEXT:   AuxSymbolCount: 1
 // CHECK-NEXT:   AuxWeakExternal {
 // CHECK-NEXT:     Linked: .weak._test_weak.default
-// CHECK-NEXT:      Search: Library
+// CHECK-NEXT:      Search: Alias
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -78,7 +78,7 @@ LBB0_2:                                 # %return
 // CHECK-NEXT:   AuxSymbolCount: 1
 // CHECK-NEXT:   AuxWeakExternal {
 // CHECK-NEXT:     Linked: .weak._test_weak_alias.default
-// CHECK-NEXT:      Search: Library
+// CHECK-NEXT:      Search: Alias
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 

--- a/test/Object/X86/nm-coff.s
+++ b/test/Object/X86/nm-coff.s
@@ -1,9 +1,14 @@
-// RUN: llvm-mc %s -o %t -filetype=obj -triple=x86_64-pc-win32
-// RUN: llvm-nm --undefined-only %t | FileCheck %s
-// CHECK: w foo
+// RUN: llvm-mc -triple x86_64-unknown-windows-msvc -filetype obj -o - %s | llvm-readobj --symbols - | FileCheck %s
 
 g:
 	movl	foo(%rip), %eax
 	retq
 
 	.weak	foo
+
+// CHECK: Symbol {
+// CHECK:   Name: foo
+// CHECK:   Section: IMAGE_SYM_UNDEFINED (0)
+// CHECK:   StorageClass: WeakExternal (0x69)
+// CHECK: }
+


### PR DESCRIPTION
The weak alias should have the characteristics set to
`IMAGE_EXTERN_WEAK_SEARCH_ALIAS` to indicate that the weak external here
is a symbol alias and that the symbol is aliased to a locally defined
symbol.  We were previously setting the characteristics to
`IMAGE_EXTERN_WEAK_SEARCH_LIBRARY` which indicates that the symbol
should be looked for in the libraries.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@364370 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 4c2ebe6d8dab32c92f47f1316e6b61374f474048)