### PR TITLE
[VFS] Add reverse iterator to OverlayFileSystem

### DIFF
--- a/include/llvm/Support/VirtualFileSystem.h
+++ b/include/llvm/Support/VirtualFileSystem.h
@@ -336,15 +336,24 @@ public:
 
   using iterator = FileSystemList::reverse_iterator;
   using const_iterator = FileSystemList::const_reverse_iterator;
+  using reverse_iterator = FileSystemList::iterator;
+  using const_reverse_iterator = FileSystemList::const_iterator;
 
   /// Get an iterator pointing to the most recently added file system.
   iterator overlays_begin() { return FSList.rbegin(); }
   const_iterator overlays_begin() const { return FSList.rbegin(); }
 
-  /// Get an iterator pointing one-past the least recently added file
-  /// system.
+  /// Get an iterator pointing one-past the least recently added file system.
   iterator overlays_end() { return FSList.rend(); }
   const_iterator overlays_end() const { return FSList.rend(); }
+
+  /// Get an iterator pointing to the least recently added file system.
+  reverse_iterator overlays_rbegin() { return FSList.begin(); }
+  const_reverse_iterator overlays_rbegin() const { return FSList.begin(); }
+
+  /// Get an iterator pointing one-past the most recently added file system.
+  reverse_iterator overlays_rend() { return FSList.end(); }
+  const_reverse_iterator overlays_rend() const { return FSList.end(); }
 };
 
 /// By default, this delegates all calls to the underlying file system. This

--- a/unittests/Support/VirtualFileSystemTest.cpp
+++ b/unittests/Support/VirtualFileSystemTest.cpp
@@ -343,6 +343,57 @@ TEST(VirtualFileSystemTest, MergedDirPermissions) {
   EXPECT_EQ(0200, Status->getPermissions());
 }
 
+TEST(VirtualFileSystemTest, OverlayIterator) {
+  IntrusiveRefCntPtr<DummyFileSystem> Lower(new DummyFileSystem());
+  Lower->addRegularFile("/foo");
+  IntrusiveRefCntPtr<DummyFileSystem> Upper(new DummyFileSystem());
+
+  IntrusiveRefCntPtr<vfs::OverlayFileSystem> O(
+      new vfs::OverlayFileSystem(Lower));
+  O->pushOverlay(Upper);
+
+  ErrorOr<vfs::Status> Status((std::error_code()));
+  {
+    auto it = O->overlays_begin();
+    auto end = O->overlays_end();
+
+    EXPECT_NE(it, end);
+
+    Status = (*it)->status("/foo");
+    ASSERT_TRUE(Status.getError());
+
+    it++;
+    EXPECT_NE(it, end);
+
+    Status = (*it)->status("/foo");
+    ASSERT_FALSE(Status.getError());
+    EXPECT_TRUE(Status->exists());
+
+    it++;
+    EXPECT_EQ(it, end);
+  }
+
+  {
+    auto it = O->overlays_rbegin();
+    auto end = O->overlays_rend();
+
+    EXPECT_NE(it, end);
+
+    Status = (*it)->status("/foo");
+    ASSERT_FALSE(Status.getError());
+    EXPECT_TRUE(Status->exists());
+
+    it++;
+    EXPECT_NE(it, end);
+
+    Status = (*it)->status("/foo");
+    ASSERT_TRUE(Status.getError());
+
+    it++;
+    EXPECT_EQ(it, end);
+  }
+}
+
 namespace {
 struct ScopedDir {
   SmallString<128> Path;


### PR DESCRIPTION
Add a reverse iterator to the overlay file system. This makes it
possible to take overlays from one OverlayFileSystem, and add them to
another.

Differential revision: https://reviews.llvm.org/D64113

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@364986 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 3dc9416c85f0f8a8ed48e2c95d53aac160eff7ab)