### PR TITLE
Add TinyPtrVector support for general pointer-like things.

### DIFF
--- a/include/llvm/ADT/PointerUnion.h
+++ b/include/llvm/ADT/PointerUnion.h
@@ -167,10 +167,11 @@ class PointerUnion
               void *, pointer_union_detail::bitsRequired(sizeof...(PTs)), int,
               pointer_union_detail::PointerUnionUIntTraits<PTs...>>,
           0, PTs...> {
-  // The first type is special in some ways, but we don't want PointerUnion to
-  // be a 'template <typename First, typename ...Rest>' because it's much more
-  // convenient to have a name for the whole pack. So split off the first type
-  // here.
+  // The first type is special because we want to directly cast a pointer to a
+  // default-initialized union to a pointer to the first type. But we don't
+  // want PointerUnion to be a 'template <typename First, typename ...Rest>'
+  // because it's much more convenient to have a name for the whole pack. So
+  // split off the first type here.
   using First = typename pointer_union_detail::GetFirstType<PTs...>::type;
   using Base = typename PointerUnion::PointerUnionMembers;
 
@@ -182,12 +183,7 @@ public:
 
   /// Test if the pointer held in the union is null, regardless of
   /// which type it is.
-  bool isNull() const {
-    // Convert from the void* to one of the pointer types, to make sure that
-    // we recursively strip off low bits if we have a nested PointerUnion.
-    return !PointerLikeTypeTraits<First>::getFromVoidPointer(
-        this->Val.getPointer());
-  }
+  bool isNull() const { return !this->Val.getPointer(); }
 
   explicit operator bool() const { return !isNull(); }
 
@@ -226,7 +222,8 @@ public:
   First *getAddrOfPtr1() {
     assert(is<First>() && "Val is not the first pointer");
     assert(
-        get<First>() == this->Val.getPointer() &&
+        PointerLikeTypeTraits<First>::getAsVoidPointer(get<First>()) ==
+            this->Val.getPointer() &&
         "Can't get the address because PointerLikeTypeTraits changes the ptr");
     return const_cast<First *>(
         reinterpret_cast<const First *>(this->Val.getAddrOfPointer()));

--- a/unittests/ADT/PointerUnionTest.cpp
+++ b/unittests/ADT/PointerUnionTest.cpp
@@ -13,14 +13,25 @@ using namespace llvm;
 namespace {
 
 typedef PointerUnion<int *, float *> PU;
+typedef PointerUnion3<int *, float *, long long *> PU3;
+typedef PointerUnion4<int *, float *, long long *, double *> PU4;
 
 struct PointerUnionTest : public testing::Test {
   float f;
   int i;
+  double d;
+  long long l;
 
   PU a, b, c, n;
+  PU3 i3, f3, l3;
+  PU4 i4, f4, l4, d4;
+  PU4 i4null, f4null, l4null, d4null;
 
-  PointerUnionTest() : f(3.14f), i(42), a(&f), b(&i), c(&i), n() {}
+  PointerUnionTest()
+      : f(3.14f), i(42), d(3.14), l(42), a(&f), b(&i), c(&i), n(), i3(&i),
+        f3(&f), l3(&l), i4(&i), f4(&f), l4(&l), d4(&d), i4null((int *)nullptr),
+        f4null((float *)nullptr), l4null((long long *)nullptr),
+        d4null((double *)nullptr) {}
 };
 
 TEST_F(PointerUnionTest, Comparison) {
@@ -32,6 +43,19 @@ TEST_F(PointerUnionTest, Comparison) {
   EXPECT_FALSE(b != c);
   EXPECT_TRUE(b != n);
   EXPECT_FALSE(b == n);
+  EXPECT_TRUE(i3 == i3);
+  EXPECT_FALSE(i3 != i3);
+  EXPECT_TRUE(i3 != f3);
+  EXPECT_TRUE(f3 != l3);
+  EXPECT_TRUE(i4 == i4);
+  EXPECT_FALSE(i4 != i4);
+  EXPECT_TRUE(i4 != f4);
+  EXPECT_TRUE(i4 != l4);
+  EXPECT_TRUE(f4 != l4);
+  EXPECT_TRUE(l4 != d4);
+  EXPECT_TRUE(i4null != f4null);
+  EXPECT_TRUE(i4null != l4null);
+  EXPECT_TRUE(i4null != d4null);
 }
 
 TEST_F(PointerUnionTest, Null) {
@@ -51,6 +75,17 @@ TEST_F(PointerUnionTest, Null) {
   b = nullptr;
   EXPECT_EQ(n, b);
   EXPECT_NE(b, c);
+  EXPECT_FALSE(i3.isNull());
+  EXPECT_FALSE(f3.isNull());
+  EXPECT_FALSE(l3.isNull());
+  EXPECT_FALSE(i4.isNull());
+  EXPECT_FALSE(f4.isNull());
+  EXPECT_FALSE(l4.isNull());
+  EXPECT_FALSE(d4.isNull());
+  EXPECT_TRUE(i4null.isNull());
+  EXPECT_TRUE(f4null.isNull());
+  EXPECT_TRUE(l4null.isNull());
+  EXPECT_TRUE(d4null.isNull());
 }
 
 TEST_F(PointerUnionTest, Is) {
@@ -60,6 +95,17 @@ TEST_F(PointerUnionTest, Is) {
   EXPECT_FALSE(b.is<float *>());
   EXPECT_TRUE(n.is<int *>());
   EXPECT_FALSE(n.is<float *>());
+  EXPECT_TRUE(i3.is<int *>());
+  EXPECT_TRUE(f3.is<float *>());
+  EXPECT_TRUE(l3.is<long long *>());
+  EXPECT_TRUE(i4.is<int *>());
+  EXPECT_TRUE(f4.is<float *>());
+  EXPECT_TRUE(l4.is<long long *>());
+  EXPECT_TRUE(d4.is<double *>());
+  EXPECT_TRUE(i4null.is<int *>());
+  EXPECT_TRUE(f4null.is<float *>());
+  EXPECT_TRUE(l4null.is<long long *>());
+  EXPECT_TRUE(d4null.is<double *>());
 }
 
 TEST_F(PointerUnionTest, Get) {
@@ -103,6 +149,11 @@ TEST_F(PointerUnionTest, ManyElements) {
 
   EXPECT_TRUE(a == PU8(&a7));
   EXPECT_TRUE(a != PU8(&a0));
+}
+
+TEST_F(PointerUnionTest, GetAddrOfPtr1) {
+  EXPECT_TRUE((void *)b.getAddrOfPtr1() == (void *)&b);
+  EXPECT_TRUE((void *)n.getAddrOfPtr1() == (void *)&n);
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
In particular, make TinyPtrVector<PtrIntPair<T *, 1>> work. Remove all
unnecessary assumptions that the element type has a formal "null"
representation. The important property to maintain is that
default-constructed element type has the same internal representation
as the default-constructed PointerUnion (all zero bits).

Remove the incorrect recursive behavior from
PointerUnion::isNull. This was never generally correct because it only
recursed over the first type parameter. With variadic templates it's
completely unnecessary.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@369473 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 30b148e81a570c4d741fe23a4c222960aaaabe51)