### PR TITLE
[LitConfig] Silenced notes/warnings on quiet.

### DIFF
--- a/utils/lit/lit/LitConfig.py
+++ b/utils/lit/lit/LitConfig.py
@@ -164,10 +164,12 @@ class LitConfig(object):
                                                kind, message))
 
     def note(self, message):
-        self._write_message('note', message)
+        if not self.quiet:
+            self._write_message('note', message)
 
     def warning(self, message):
-        self._write_message('warning', message)
+        if not self.quiet:
+            self._write_message('warning', message)
         self.numWarnings += 1
 
     def error(self, message):


### PR DESCRIPTION
Lit has a "quiet" option, -q, which is documented to "suppress no error output". Previously, LitConfig displayed notes and warnings when the quiet option was specified. The result was that it was not possible to get only pertinent file/line information to be used by an editor to jump to the location where checks were failing without passing a number of unhelpful locations first. Here, the implementations of LitConfig.note and LitConfig.warning are modified to account for the quiet flag and avoid displaying if the flag has indeed been set.