### PR TITLE
Revert "lld support"

### DIFF
--- a/include/llvm/ADT/STLExtras.h
+++ b/include/llvm/ADT/STLExtras.h
@@ -1322,12 +1322,44 @@ void stable_sort(R &&Range, Compare C) {
   std::stable_sort(adl_begin(Range), adl_end(Range), C);
 }
 
-/// Binary search for the first iterator in a range where a predicate is false.
-/// Requires that C is always true below some limit, and always false above it.
-template <typename R, typename Predicate,
-          typename Val = decltype(*adl_begin(std::declval<R>()))>
-auto partition_point(R &&Range, Predicate P) -> decltype(adl_begin(Range)) {
-  return std::partition_point(adl_begin(Range), adl_end(Range), P);
+/// Binary search for the first index where a predicate is true.
+/// Returns the first I in [Lo, Hi) where C(I) is true, or Hi if it never is.
+/// Requires that C is always false below some limit, and always true above it.
+///
+/// Example:
+///   size_t DawnModernEra = bsearch(1776, 2050, [](size_t Year){
+///     return Presidents.for(Year).twitterHandle() != None;
+///   });
+///
+/// Note the return value differs from std::binary_search!
+template <typename Predicate>
+size_t bsearch(size_t Lo, size_t Hi, Predicate P) {
+  while (Lo != Hi) {
+    assert(Hi > Lo);
+    size_t Mid = Lo + (Hi - Lo) / 2;
+    if (P(Mid))
+      Hi = Mid;
+    else
+      Lo = Mid + 1;
+  }
+  return Hi;
+}
+
+/// Binary search for the first iterator where a predicate is true.
+/// Returns the first I in [Lo, Hi) where C(*I) is true, or Hi if it never is.
+/// Requires that C is always false below some limit, and always true above it.
+template <typename It, typename Predicate,
+          typename Val = decltype(*std::declval<It>())>
+It bsearch(It Lo, It Hi, Predicate P) {
+  return std::lower_bound(Lo, Hi, 0u,
+                          [&](const Val &V, unsigned) { return !P(V); });
+}
+
+/// Binary search for the first iterator in a range where a predicate is true.
+/// Requires that C is always false below some limit, and always true above it.
+template <typename R, typename Predicate>
+auto bsearch(R &&Range, Predicate P) -> decltype(adl_begin(Range)) {
+  return bsearch(adl_begin(Range), adl_end(Range), P);
 }
 
 /// Wrapper function around std::equal to detect if all elements

--- a/include/llvm/BinaryFormat/Wasm.h
+++ b/include/llvm/BinaryFormat/Wasm.h
@@ -242,18 +242,13 @@ enum : unsigned {
 enum : unsigned {
   WASM_OPCODE_END = 0x0b,
   WASM_OPCODE_CALL = 0x10,
-  WASM_OPCODE_LOCAL_GET = 0x20,
   WASM_OPCODE_GLOBAL_GET = 0x23,
-  WASM_OPCODE_GLOBAL_SET = 0x24,
   WASM_OPCODE_I32_STORE = 0x36,
   WASM_OPCODE_I32_CONST = 0x41,
   WASM_OPCODE_I64_CONST = 0x42,
   WASM_OPCODE_F32_CONST = 0x43,
   WASM_OPCODE_F64_CONST = 0x44,
   WASM_OPCODE_I32_ADD = 0x6a,
-  WASM_OPCODE_MISC_PREFIX = 0xfc,
-  WASM_OPCODE_MEMORY_INIT = 0x08,
-  WASM_OPCODE_DATA_DROP = 0x09,
 };
 
 enum : unsigned {
@@ -369,7 +364,6 @@ inline bool operator!=(const WasmGlobalType &LHS, const WasmGlobalType &RHS) {
 
 std::string toString(WasmSymbolType type);
 std::string relocTypetoString(uint32_t type);
-bool relocTypeHasAddend(uint32_t type);
 
 } // end namespace wasm
 } // end namespace llvm

--- a/include/llvm/CodeGen/SlotIndexes.h
+++ b/include/llvm/CodeGen/SlotIndexes.h
@@ -308,6 +308,20 @@ class raw_ostream;
 
   using IdxMBBPair = std::pair<SlotIndex, MachineBasicBlock *>;
 
+  inline bool operator<(SlotIndex V, const IdxMBBPair &IM) {
+    return V < IM.first;
+  }
+
+  inline bool operator<(const IdxMBBPair &IM, SlotIndex V) {
+    return IM.first < V;
+  }
+
+  struct Idx2MBBCompare {
+    bool operator()(const IdxMBBPair &LHS, const IdxMBBPair &RHS) const {
+      return LHS.first < RHS.first;
+    }
+  };
+
   /// SlotIndexes pass.
   ///
   /// This pass assigns indexes to each instruction.
@@ -499,9 +513,7 @@ class raw_ostream;
     /// Move iterator to the next IdxMBBPair where the SlotIndex is greater or
     /// equal to \p To.
     MBBIndexIterator advanceMBBIndex(MBBIndexIterator I, SlotIndex To) const {
-      return std::partition_point(
-          I, idx2MBBMap.end(),
-          [=](const IdxMBBPair &IM) { return IM.first < To; });
+      return std::lower_bound(I, idx2MBBMap.end(), To);
     }
 
     /// Get an iterator pointing to the IdxMBBPair with the biggest SlotIndex
@@ -665,7 +677,7 @@ class raw_ostream;
       idx2MBBMap.push_back(IdxMBBPair(startIdx, mbb));
 
       renumberIndexes(newItr);
-      llvm::sort(idx2MBBMap, less_first());
+      llvm::sort(idx2MBBMap, Idx2MBBCompare());
     }
 
     /// Free the resources that were required to maintain a SlotIndex.

--- a/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -473,10 +473,9 @@ public:
   DWARFDie getDIEForOffset(uint64_t Offset) {
     extractDIEsIfNeeded(false);
     assert(!DieArray.empty());
-    auto It =
-        llvm::partition_point(DieArray, [=](const DWARFDebugInfoEntry &DIE) {
-          return DIE.getOffset() < Offset;
-        });
+    auto It = llvm::bsearch(DieArray, [=](const DWARFDebugInfoEntry &LHS) {
+      return Offset <= LHS.getOffset();
+    });
     if (It != DieArray.end() && It->getOffset() == Offset)
       return DWARFDie(this, &*It);
     return DWARFDie();

--- a/include/llvm/IR/IntrinsicsWebAssembly.td
+++ b/include/llvm/IR/IntrinsicsWebAssembly.td
@@ -124,13 +124,4 @@ def int_wasm_data_drop :
             [llvm_i32_ty],
             [IntrNoDuplicate, IntrHasSideEffects, ImmArg<0>]>;
 
-//===----------------------------------------------------------------------===//
-// Thread-local storage intrinsics
-//===----------------------------------------------------------------------===//
-
-def int_wasm_tls_size :
-  Intrinsic<[llvm_anyint_ty],
-            [],
-            [IntrNoMem, IntrSpeculatable]>;
-
 } // TargetPrefix = "wasm"

--- a/include/llvm/MC/MCSectionWasm.h
+++ b/include/llvm/MC/MCSectionWasm.h
@@ -66,8 +66,7 @@ public:
   bool isVirtualSection() const override;
 
   bool isWasmData() const {
-    return Kind.isGlobalWriteableData() || Kind.isReadOnly() ||
-           Kind.isThreadLocal();
+    return Kind.isGlobalWriteableData() || Kind.isReadOnly();
   }
 
   bool isUnique() const { return UniqueID != ~0U; }

--- a/include/llvm/Object/ELFObjectFile.h
+++ b/include/llvm/Object/ELFObjectFile.h
@@ -54,6 +54,7 @@ class ELFObjectFileBase : public ObjectFile {
 protected:
   ELFObjectFileBase(unsigned int Type, MemoryBufferRef Source);
 
+  virtual uint16_t getEMachine() const = 0;
   virtual uint64_t getSymbolSize(DataRefImpl Symb) const = 0;
   virtual uint8_t getSymbolBinding(DataRefImpl Symb) const = 0;
   virtual uint8_t getSymbolOther(DataRefImpl Symb) const = 0;
@@ -89,8 +90,6 @@ public:
   void setARMSubArch(Triple &TheTriple) const override;
 
   virtual uint16_t getEType() const = 0;
-
-  virtual uint16_t getEMachine() const = 0;
 
   std::vector<std::pair<DataRefImpl, uint64_t>> getPltAddresses() const;
 };

--- a/lib/Analysis/ProfileSummaryInfo.cpp
+++ b/lib/Analysis/ProfileSummaryInfo.cpp
@@ -60,9 +60,10 @@ static cl::opt<int> ProfileSummaryColdCount(
 // Find the summary entry for a desired percentile of counts.
 static const ProfileSummaryEntry &getEntryForPercentile(SummaryEntryVector &DS,
                                                         uint64_t Percentile) {
-  auto It = partition_point(DS, [=](const ProfileSummaryEntry &Entry) {
+  auto Compare = [](const ProfileSummaryEntry &Entry, uint64_t Percentile) {
     return Entry.Cutoff < Percentile;
-  });
+  };
+  auto It = std::lower_bound(DS.begin(), DS.end(), Percentile, Compare);
   // The required percentile has to be <= one of the percentiles in the
   // detailed summary.
   if (It == DS.end())

--- a/lib/BinaryFormat/Wasm.cpp
+++ b/lib/BinaryFormat/Wasm.cpp
@@ -35,17 +35,3 @@ std::string llvm::wasm::relocTypetoString(uint32_t Type) {
     llvm_unreachable("unknown reloc type");
   }
 }
-
-bool llvm::wasm::relocTypeHasAddend(uint32_t Type) {
-  switch (Type) {
-  case R_WASM_MEMORY_ADDR_LEB:
-  case R_WASM_MEMORY_ADDR_SLEB:
-  case R_WASM_MEMORY_ADDR_REL_SLEB:
-  case R_WASM_MEMORY_ADDR_I32:
-  case R_WASM_FUNCTION_OFFSET_I32:
-  case R_WASM_SECTION_OFFSET_I32:
-    return true;
-  default:
-    return false;
-  }
-}

--- a/lib/CodeGen/ExecutionDomainFix.cpp
+++ b/lib/CodeGen/ExecutionDomainFix.cpp
@@ -337,8 +337,8 @@ void ExecutionDomainFix::visitSoftInstr(MachineInstr *mi, unsigned mask) {
     // Sorted insertion.
     // Enables giving priority to the latest domains during merging.
     const int Def = RDA->getReachingDef(mi, RC->getRegister(rx));
-    auto I = partition_point(Regs, [&](int I) {
-      return RDA->getReachingDef(mi, RC->getRegister(I)) <= Def;
+    auto I = llvm::bsearch(Regs, [&](int I) {
+      return Def < RDA->getReachingDef(mi, RC->getRegister(I));
     });
     Regs.insert(I, rx);
   }

--- a/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
+++ b/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
@@ -544,10 +544,11 @@ LegalizerInfo::findAction(const SizeAndActionsVec &Vec, const uint32_t Size) {
   // Find the last element in Vec that has a bitsize equal to or smaller than
   // the requested bit size.
   // That is the element just before the first element that is bigger than Size.
-  auto It = partition_point(
-      Vec, [=](const SizeAndAction &A) { return A.first <= Size; });
-  assert(It != Vec.begin() && "Does Vec not start with size 1?");
-  int VecIdx = It - Vec.begin() - 1;
+  auto VecIt = llvm::bsearch(
+      Vec, [=](const SizeAndAction &A) { return Size < A.first; });
+  assert(VecIt != Vec.begin() && "Does Vec not start with size 1?");
+  --VecIt;
+  int VecIdx = VecIt - Vec.begin();
 
   LegalizeAction Action = Vec[VecIdx].second;
   switch (Action) {

--- a/lib/CodeGen/LiveIntervals.cpp
+++ b/lib/CodeGen/LiveIntervals.cpp
@@ -900,7 +900,8 @@ bool LiveIntervals::checkRegMaskInterference(LiveInterval &LI,
 
   // We are going to enumerate all the register mask slots contained in LI.
   // Start with a binary search of RegMaskSlots to find a starting point.
-  ArrayRef<SlotIndex>::iterator SlotI = llvm::lower_bound(Slots, LiveI->start);
+  ArrayRef<SlotIndex>::iterator SlotI =
+    std::lower_bound(Slots.begin(), Slots.end(), LiveI->start);
   ArrayRef<SlotIndex>::iterator SlotE = Slots.end();
 
   // No slots in range, LI begins after the last call.
@@ -1369,7 +1370,8 @@ private:
 
   void updateRegMaskSlots() {
     SmallVectorImpl<SlotIndex>::iterator RI =
-        llvm::lower_bound(LIS.RegMaskSlots, OldIdx);
+      std::lower_bound(LIS.RegMaskSlots.begin(), LIS.RegMaskSlots.end(),
+                       OldIdx);
     assert(RI != LIS.RegMaskSlots.end() && *RI == OldIdx.getRegSlot() &&
            "No RegMask at OldIdx.");
     *RI = NewIdx.getRegSlot();

--- a/lib/CodeGen/MachinePipeliner.cpp
+++ b/lib/CodeGen/MachinePipeliner.cpp
@@ -3726,8 +3726,9 @@ void SwingSchedulerDAG::checkValidNodeOrder(const NodeSetType &Circuits) const {
 
     for (SDep &PredEdge : SU->Preds) {
       SUnit *PredSU = PredEdge.getSUnit();
-      unsigned PredIndex = std::get<1>(
-          *llvm::lower_bound(Indices, std::make_pair(PredSU, 0), CompareKey));
+      unsigned PredIndex =
+          std::get<1>(*std::lower_bound(Indices.begin(), Indices.end(),
+                                        std::make_pair(PredSU, 0), CompareKey));
       if (!PredSU->getInstr()->isPHI() && PredIndex < Index) {
         PredBefore = true;
         Pred = PredSU;
@@ -3742,8 +3743,9 @@ void SwingSchedulerDAG::checkValidNodeOrder(const NodeSetType &Circuits) const {
       // return Indices.end().
       if (SuccSU->isBoundaryNode())
         continue;
-      unsigned SuccIndex = std::get<1>(
-          *llvm::lower_bound(Indices, std::make_pair(SuccSU, 0), CompareKey));
+      unsigned SuccIndex =
+          std::get<1>(*std::lower_bound(Indices.begin(), Indices.end(),
+                                        std::make_pair(SuccSU, 0), CompareKey));
       if (!SuccSU->getInstr()->isPHI() && SuccIndex < Index) {
         SuccBefore = true;
         Succ = SuccSU;
@@ -3754,8 +3756,9 @@ void SwingSchedulerDAG::checkValidNodeOrder(const NodeSetType &Circuits) const {
     if (PredBefore && SuccBefore && !SU->getInstr()->isPHI()) {
       // instructions in circuits are allowed to be scheduled
       // after both a successor and predecessor.
-      bool InCircuit = llvm::any_of(
-          Circuits, [SU](const NodeSet &Circuit) { return Circuit.count(SU); });
+      bool InCircuit = std::any_of(
+          Circuits.begin(), Circuits.end(),
+          [SU](const NodeSet &Circuit) { return Circuit.count(SU); });
       if (InCircuit)
         LLVM_DEBUG(dbgs() << "In a circuit, predecessor ";);
       else {

--- a/lib/CodeGen/SlotIndexes.cpp
+++ b/lib/CodeGen/SlotIndexes.cpp
@@ -94,7 +94,7 @@ bool SlotIndexes::runOnMachineFunction(MachineFunction &fn) {
   }
 
   // Sort the Idx2MBBMap
-  llvm::sort(idx2MBBMap, less_first());
+  llvm::sort(idx2MBBMap, Idx2MBBCompare());
 
   LLVM_DEBUG(mf->print(dbgs(), this));
 

--- a/lib/DebugInfo/DWARF/DWARFDebugAranges.cpp
+++ b/lib/DebugInfo/DWARF/DWARFDebugAranges.cpp
@@ -115,7 +115,7 @@ void DWARFDebugAranges::construct() {
 
 uint32_t DWARFDebugAranges::findAddress(uint64_t Address) const {
   RangeCollIterator It =
-      partition_point(Aranges, [=](Range R) { return R.HighPC() <= Address; });
+      llvm::bsearch(Aranges, [=](Range RHS) { return Address < RHS.HighPC(); });
   if (It != Aranges.end() && It->LowPC <= Address)
     return It->CUOffset;
   return -1U;

--- a/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
+++ b/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
@@ -532,9 +532,10 @@ void DWARFDebugFrame::parse(DWARFDataExtractor Data) {
 }
 
 FrameEntry *DWARFDebugFrame::getEntryAtOffset(uint64_t Offset) const {
-  auto It = partition_point(Entries, [=](const std::unique_ptr<FrameEntry> &E) {
-    return E->getOffset() < Offset;
-  });
+  auto It =
+      std::lower_bound(Entries.begin(), Entries.end(), Offset,
+                       [](const std::unique_ptr<FrameEntry> &E,
+                          uint64_t Offset) { return E->getOffset() < Offset; });
   if (It != Entries.end() && (*It)->getOffset() == Offset)
     return It->get();
   return nullptr;

--- a/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
+++ b/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
@@ -57,8 +57,8 @@ void DWARFDebugLoc::LocationList::dump(raw_ostream &OS, bool IsLittleEndian,
 
 DWARFDebugLoc::LocationList const *
 DWARFDebugLoc::getLocationListAtOffset(uint64_t Offset) const {
-  auto It = partition_point(
-      Locations, [=](const LocationList &L) { return L.Offset < Offset; });
+  auto It = llvm::bsearch(
+      Locations, [=](const LocationList &L) { return Offset <= L.Offset; });
   if (It != Locations.end() && It->Offset == Offset)
     return &(*It);
   return nullptr;
@@ -212,8 +212,8 @@ void DWARFDebugLoclists::parse(DataExtractor data, unsigned Version) {
 
 DWARFDebugLoclists::LocationList const *
 DWARFDebugLoclists::getLocationListAtOffset(uint64_t Offset) const {
-  auto It = partition_point(
-      Locations, [=](const LocationList &L) { return L.Offset < Offset; });
+  auto It = llvm::bsearch(
+      Locations, [=](const LocationList &L) { return Offset <= L.Offset; });
   if (It != Locations.end() && It->Offset == Offset)
     return &(*It);
   return nullptr;

--- a/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -172,8 +172,8 @@ DWARFUnitIndex::getFromOffset(uint32_t Offset) const {
              E2->Contributions[InfoColumn].Offset;
     });
   }
-  auto I = partition_point(OffsetLookup, [&](Entry *E2) {
-    return E2->Contributions[InfoColumn].Offset <= Offset;
+  auto I = llvm::bsearch(OffsetLookup, [&](Entry *E2) {
+    return Offset < E2->Contributions[InfoColumn].Offset;
   });
   if (I == OffsetLookup.begin())
     return nullptr;

--- a/lib/IR/DataLayout.cpp
+++ b/lib/IR/DataLayout.cpp
@@ -463,9 +463,12 @@ DataLayout::AlignmentsTy::iterator
 DataLayout::findAlignmentLowerBound(AlignTypeEnum AlignType,
                                     uint32_t BitWidth) {
   auto Pair = std::make_pair((unsigned)AlignType, BitWidth);
-  return partition_point(Alignments, [=](const LayoutAlignElem &E) {
-    return std::make_pair(E.AlignType, E.TypeBitWidth) < Pair;
-  });
+  return std::lower_bound(Alignments.begin(), Alignments.end(), Pair,
+                          [](const LayoutAlignElem &LHS,
+                             const std::pair<unsigned, uint32_t> &RHS) {
+                            return std::tie(LHS.AlignType, LHS.TypeBitWidth) <
+                                   std::tie(RHS.first, RHS.second);
+                          });
 }
 
 void

--- a/lib/IR/Function.cpp
+++ b/lib/IR/Function.cpp
@@ -533,8 +533,9 @@ static ArrayRef<const char *> findTargetSubtable(StringRef Name) {
   // Drop "llvm." and take the first dotted component. That will be the target
   // if this is target specific.
   StringRef Target = Name.drop_front(5).split('.').first;
-  auto It = partition_point(
-      Targets, [=](const IntrinsicTargetInfo &TI) { return TI.Name < Target; });
+  auto It = std::lower_bound(Targets.begin(), Targets.end(), Target,
+                             [](const IntrinsicTargetInfo &TI,
+                                StringRef Target) { return TI.Name < Target; });
   // We've either found the target or just fall back to the generic set, which
   // is always first.
   const auto &TI = It != Targets.end() && It->Name == Target ? *It : Targets[0];

--- a/lib/MC/MCSubtargetInfo.cpp
+++ b/lib/MC/MCSubtargetInfo.cpp
@@ -24,7 +24,7 @@ using namespace llvm;
 template <typename T>
 static const T *Find(StringRef S, ArrayRef<T> A) {
   // Binary search the array
-  auto F = llvm::lower_bound(A, S);
+  auto F = std::lower_bound(A.begin(), A.end(), S);
   // If not found then return NULL
   if (F == A.end() || StringRef(F->Key) != S) return nullptr;
   // Return the found array item

--- a/lib/MC/WasmObjectWriter.cpp
+++ b/lib/MC/WasmObjectWriter.cpp
@@ -147,7 +147,19 @@ struct WasmRelocationEntry {
       : Offset(Offset), Symbol(Symbol), Addend(Addend), Type(Type),
         FixupSection(FixupSection) {}
 
-  bool hasAddend() const { return wasm::relocTypeHasAddend(Type); }
+  bool hasAddend() const {
+    switch (Type) {
+    case wasm::R_WASM_MEMORY_ADDR_LEB:
+    case wasm::R_WASM_MEMORY_ADDR_SLEB:
+    case wasm::R_WASM_MEMORY_ADDR_REL_SLEB:
+    case wasm::R_WASM_MEMORY_ADDR_I32:
+    case wasm::R_WASM_FUNCTION_OFFSET_I32:
+    case wasm::R_WASM_SECTION_OFFSET_I32:
+      return true;
+    default:
+      return false;
+    }
+  }
 
   void print(raw_ostream &Out) const {
     Out << wasm::relocTypetoString(Type) << " Off=" << Offset

--- a/lib/ProfileData/InstrProf.cpp
+++ b/lib/ProfileData/InstrProf.cpp
@@ -363,15 +363,16 @@ Error InstrProfSymtab::create(Module &M, bool InLTO) {
 
 uint64_t InstrProfSymtab::getFunctionHashFromAddress(uint64_t Address) {
   finalizeSymtab();
-  auto It = partition_point(AddrToMD5Map, [=](std::pair<uint64_t, uint64_t> A) {
-    return A.first < Address;
-  });
+  auto Result =
+      std::lower_bound(AddrToMD5Map.begin(), AddrToMD5Map.end(), Address,
+                       [](const std::pair<uint64_t, uint64_t> &LHS,
+                          uint64_t RHS) { return LHS.first < RHS; });
   // Raw function pointer collected by value profiler may be from
   // external functions that are not instrumented. They won't have
   // mapping data to be used by the deserializer. Force the value to
   // be 0 in this case.
-  if (It != AddrToMD5Map.end() && It->first == Address)
-    return (uint64_t)It->second;
+  if (Result != AddrToMD5Map.end() && Result->first == Address)
+    return (uint64_t)Result->second;
   return 0;
 }
 

--- a/lib/Support/SourceMgr.cpp
+++ b/lib/Support/SourceMgr.cpp
@@ -95,9 +95,14 @@ unsigned SourceMgr::SrcBuffer::getLineNumber(const char *Ptr) const {
   assert(PtrDiff >= 0 && static_cast<size_t>(PtrDiff) <= std::numeric_limits<T>::max());
   T PtrOffset = static_cast<T>(PtrDiff);
 
-  // llvm::lower_bound gives the number of EOL before PtrOffset. Add 1 to get
-  // the line number.
-  return llvm::lower_bound(*Offsets, PtrOffset) - Offsets->begin() + 1;
+  // std::lower_bound returns the first EOL offset that's not-less-than
+  // PtrOffset, meaning the EOL that _ends the line_ that PtrOffset is on
+  // (including if PtrOffset refers to the EOL itself). If there's no such
+  // EOL, returns end().
+  auto EOL = std::lower_bound(Offsets->begin(), Offsets->end(), PtrOffset);
+
+  // Lines count from 1, so add 1 to the distance from the 0th line.
+  return (1 + (EOL - Offsets->begin()));
 }
 
 SourceMgr::SrcBuffer::SrcBuffer(SourceMgr::SrcBuffer &&Other)

--- a/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -875,7 +875,9 @@ void ARMConstantIslands::updateForInsertedWaterBlock(MachineBasicBlock *NewBB) {
 
   // Next, update WaterList.  Specifically, we need to add NewMBB as having
   // available water after it.
-  water_iterator IP = llvm::lower_bound(WaterList, NewBB, CompareMBBNumbers);
+  water_iterator IP =
+    std::lower_bound(WaterList.begin(), WaterList.end(), NewBB,
+                     CompareMBBNumbers);
   WaterList.insert(IP, NewBB);
 }
 
@@ -926,7 +928,9 @@ MachineBasicBlock *ARMConstantIslands::splitBlockBeforeInstr(MachineInstr *MI) {
   // available water after it (but not if it's already there, which happens
   // when splitting before a conditional branch that is followed by an
   // unconditional branch - in that case we want to insert NewBB).
-  water_iterator IP = llvm::lower_bound(WaterList, OrigBB, CompareMBBNumbers);
+  water_iterator IP =
+    std::lower_bound(WaterList.begin(), WaterList.end(), OrigBB,
+                     CompareMBBNumbers);
   MachineBasicBlock* WaterBB = *IP;
   if (WaterBB == OrigBB)
     WaterList.insert(std::next(IP), NewBB);

--- a/lib/Target/ARM/ARMExpandPseudoInsts.cpp
+++ b/lib/Target/ARM/ARMExpandPseudoInsts.cpp
@@ -423,7 +423,8 @@ static const NEONLdStTableEntry *LookupNEONLdSt(unsigned Opcode) {
   }
 #endif
 
-  auto I = llvm::lower_bound(NEONLdStTable, Opcode);
+  auto I = std::lower_bound(std::begin(NEONLdStTable),
+                            std::end(NEONLdStTable), Opcode);
   if (I != std::end(NEONLdStTable) && I->PseudoOpc == Opcode)
     return I;
   return nullptr;

--- a/lib/Target/Hexagon/HexagonGenInsert.cpp
+++ b/lib/Target/Hexagon/HexagonGenInsert.cpp
@@ -436,7 +436,7 @@ namespace {
 } // end anonymous namespace
 
 void OrderedRegisterList::insert(unsigned VR) {
-  iterator L = llvm::lower_bound(Seq, VR, Ord);
+  iterator L = std::lower_bound(Seq.begin(), Seq.end(), VR, Ord);
   if (L == Seq.end())
     Seq.push_back(VR);
   else
@@ -449,7 +449,7 @@ void OrderedRegisterList::insert(unsigned VR) {
 }
 
 void OrderedRegisterList::remove(unsigned VR) {
-  iterator L = llvm::lower_bound(Seq, VR, Ord);
+  iterator L = std::lower_bound(Seq.begin(), Seq.end(), VR, Ord);
   if (L != Seq.end())
     Seq.erase(L);
 }

--- a/lib/Target/Mips/Mips16ISelLowering.cpp
+++ b/lib/Target/Mips/Mips16ISelLowering.cpp
@@ -459,7 +459,8 @@ getOpndList(SmallVectorImpl<SDValue> &Ops,
         }
         // one more look at list of intrinsics
         const Mips16IntrinsicHelperType *Helper =
-            llvm::lower_bound(Mips16IntrinsicHelper, IntrinsicFind);
+            std::lower_bound(std::begin(Mips16IntrinsicHelper),
+                             std::end(Mips16IntrinsicHelper), IntrinsicFind);
         if (Helper != std::end(Mips16IntrinsicHelper) &&
             *Helper == IntrinsicFind) {
           Mips16HelperFunction = Helper->Helper;

--- a/lib/Target/Mips/MipsConstantIslandPass.cpp
+++ b/lib/Target/Mips/MipsConstantIslandPass.cpp
@@ -841,7 +841,9 @@ void MipsConstantIslands::updateForInsertedWaterBlock
 
   // Next, update WaterList.  Specifically, we need to add NewMBB as having
   // available water after it.
-  water_iterator IP = llvm::lower_bound(WaterList, NewBB, CompareMBBNumbers);
+  water_iterator IP =
+    std::lower_bound(WaterList.begin(), WaterList.end(), NewBB,
+                     CompareMBBNumbers);
   WaterList.insert(IP, NewBB);
 }
 
@@ -891,7 +893,9 @@ MipsConstantIslands::splitBlockBeforeInstr(MachineInstr &MI) {
   // available water after it (but not if it's already there, which happens
   // when splitting before a conditional branch that is followed by an
   // unconditional branch - in that case we want to insert NewBB).
-  water_iterator IP = llvm::lower_bound(WaterList, OrigBB, CompareMBBNumbers);
+  water_iterator IP =
+    std::lower_bound(WaterList.begin(), WaterList.end(), OrigBB,
+                     CompareMBBNumbers);
   MachineBasicBlock* WaterBB = *IP;
   if (WaterBB == OrigBB)
     WaterList.insert(std::next(IP), NewBB);

--- a/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -233,8 +233,6 @@ bool WebAssemblyFastISel::computeAddress(const Value *Obj, Address &Addr) {
       return false;
     if (Addr.getGlobalValue())
       return false;
-    if (GV->isThreadLocal())
-      return false;
     Addr.setGlobalValue(GV);
     return true;
   }
@@ -615,8 +613,6 @@ unsigned WebAssemblyFastISel::fastMaterializeAlloca(const AllocaInst *AI) {
 unsigned WebAssemblyFastISel::fastMaterializeConstant(const Constant *C) {
   if (const GlobalValue *GV = dyn_cast<GlobalValue>(C)) {
     if (TLI.isPositionIndependent())
-      return 0;
-    if (GV->isThreadLocal())
       return 0;
     unsigned ResultReg =
         createResultReg(Subtarget->hasAddr64() ? &WebAssembly::I64RegClass

--- a/lib/Target/WebAssembly/WebAssemblyISelDAGToDAG.cpp
+++ b/lib/Target/WebAssembly/WebAssemblyISelDAGToDAG.cpp
@@ -15,7 +15,6 @@
 #include "WebAssembly.h"
 #include "WebAssemblyTargetMachine.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
-#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h" // To access function attributes.
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/KnownBits.h"
@@ -170,54 +169,6 @@ void WebAssemblyDAGToDAGISel::Select(SDNode *Node) {
     default:
       llvm_unreachable("Unknown scope!");
     }
-  }
-
-  case ISD::GlobalTLSAddress: {
-    const auto *GA = cast<GlobalAddressSDNode>(Node);
-
-    if (!MF.getSubtarget<WebAssemblySubtarget>().hasBulkMemory())
-      report_fatal_error("cannot use thread-local storage without bulk memory",
-                         false);
-
-    if (GA->getGlobal()->getThreadLocalMode() !=
-        GlobalValue::LocalExecTLSModel) {
-      report_fatal_error("only -ftls-model=local-exec is supported for now",
-                         false);
-    }
-
-    MVT PtrVT = TLI->getPointerTy(CurDAG->getDataLayout());
-    assert(PtrVT == MVT::i32 && "only wasm32 is supported for now");
-
-    SDValue TLSBaseSym = CurDAG->getTargetExternalSymbol("__tls_base", PtrVT);
-    SDValue TLSOffsetSym = CurDAG->getTargetGlobalAddress(
-        GA->getGlobal(), DL, PtrVT, GA->getOffset(), 0);
-
-    MachineSDNode *TLSBase = CurDAG->getMachineNode(WebAssembly::GLOBAL_GET_I32,
-                                                    DL, MVT::i32, TLSBaseSym);
-    MachineSDNode *TLSOffset = CurDAG->getMachineNode(
-        WebAssembly::CONST_I32, DL, MVT::i32, TLSOffsetSym);
-    MachineSDNode *TLSAddress =
-        CurDAG->getMachineNode(WebAssembly::ADD_I32, DL, MVT::i32,
-                               SDValue(TLSBase, 0), SDValue(TLSOffset, 0));
-    ReplaceNode(Node, TLSAddress);
-    return;
-  }
-
-  case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntNo = cast<ConstantSDNode>(Node->getOperand(0))->getZExtValue();
-    switch (IntNo) {
-    case Intrinsic::wasm_tls_size: {
-      MVT PtrVT = TLI->getPointerTy(CurDAG->getDataLayout());
-      assert(PtrVT == MVT::i32 && "only wasm32 is supported for now");
-
-      MachineSDNode *TLSSize = CurDAG->getMachineNode(
-          WebAssembly::GLOBAL_GET_I32, DL, PtrVT,
-          CurDAG->getTargetExternalSymbol("__tls_size", MVT::i32));
-      ReplaceNode(Node, TLSSize);
-      return;
-    }
-    }
-    break;
   }
 
   default:

--- a/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
+++ b/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
@@ -77,11 +77,9 @@ MCSymbol *WebAssemblyMCInstLower::GetExternalSymbolSymbol(
   // functions. It's OK to hardcode knowledge of specific symbols here; this
   // method is precisely there for fetching the signatures of known
   // Clang-provided symbols.
-  if (strcmp(Name, "__stack_pointer") == 0 || strcmp(Name, "__tls_base") == 0 ||
-      strcmp(Name, "__memory_base") == 0 || strcmp(Name, "__table_base") == 0 ||
-      strcmp(Name, "__tls_size") == 0) {
-    bool Mutable =
-        strcmp(Name, "__stack_pointer") == 0 || strcmp(Name, "__tls_base") == 0;
+  if (strcmp(Name, "__stack_pointer") == 0 ||
+      strcmp(Name, "__memory_base") == 0 || strcmp(Name, "__table_base") == 0) {
+    bool Mutable = strcmp(Name, "__stack_pointer") == 0;
     WasmSym->setType(wasm::WASM_SYMBOL_TYPE_GLOBAL);
     WasmSym->setGlobalType(wasm::WasmGlobalType{
         uint8_t(Subtarget.hasAddr64() ? wasm::WASM_TYPE_I64

--- a/lib/Target/X86/X86EvexToVex.cpp
+++ b/lib/Target/X86/X86EvexToVex.cpp
@@ -252,7 +252,7 @@ bool EvexToVexInstPass::CompressEvexToVexImpl(MachineInstr &MI) const {
     (Desc.TSFlags & X86II::VEX_L) ? makeArrayRef(X86EvexToVex256CompressTable)
                                   : makeArrayRef(X86EvexToVex128CompressTable);
 
-  auto I = llvm::lower_bound(Table, MI.getOpcode());
+  auto I = std::lower_bound(Table.begin(), Table.end(), MI.getOpcode());
   if (I == Table.end() || I->EvexOpcode != MI.getOpcode())
     return false;
 

--- a/lib/Target/X86/X86FloatingPoint.cpp
+++ b/lib/Target/X86/X86FloatingPoint.cpp
@@ -596,7 +596,7 @@ namespace {
 }
 
 static int Lookup(ArrayRef<TableEntry> Table, unsigned Opcode) {
-  const TableEntry *I = llvm::lower_bound(Table, Opcode);
+  const TableEntry *I = std::lower_bound(Table.begin(), Table.end(), Opcode);
   if (I != Table.end() && I->from == Opcode)
     return I->to;
   return -1;

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -13063,9 +13063,11 @@ static SDValue lowerV8I16GeneralSingleInputShuffle(
   copy_if(HiMask, std::back_inserter(HiInputs), [](int M) { return M >= 0; });
   array_pod_sort(HiInputs.begin(), HiInputs.end());
   HiInputs.erase(std::unique(HiInputs.begin(), HiInputs.end()), HiInputs.end());
-  int NumLToL = llvm::lower_bound(LoInputs, 4) - LoInputs.begin();
+  int NumLToL =
+      std::lower_bound(LoInputs.begin(), LoInputs.end(), 4) - LoInputs.begin();
   int NumHToL = LoInputs.size() - NumLToL;
-  int NumLToH = llvm::lower_bound(HiInputs, 4) - HiInputs.begin();
+  int NumLToH =
+      std::lower_bound(HiInputs.begin(), HiInputs.end(), 4) - HiInputs.begin();
   int NumHToH = HiInputs.size() - NumLToH;
   MutableArrayRef<int> LToLInputs(LoInputs.data(), NumLToL);
   MutableArrayRef<int> LToHInputs(HiInputs.data(), NumLToH);

--- a/lib/Target/X86/X86InstrFMA3Info.cpp
+++ b/lib/Target/X86/X86InstrFMA3Info.cpp
@@ -158,9 +158,11 @@ const X86InstrFMA3Group *llvm::getFMA3Group(unsigned Opcode, uint64_t TSFlags) {
   // FMA 231 instructions have an opcode of 0xB6-0xBF
   unsigned FormIndex = ((BaseOpcode - 0x90) >> 4) & 0x3;
 
-  auto I = partition_point(Table, [=](const X86InstrFMA3Group &Group) {
-    return Group.Opcodes[FormIndex] < Opcode;
-  });
+  auto I = std::lower_bound(Table.begin(), Table.end(), Opcode,
+                            [FormIndex](const X86InstrFMA3Group &Group,
+                                        unsigned Opcode) {
+                              return Group.Opcodes[FormIndex] < Opcode;
+                            });
   assert(I != Table.end() && I->Opcodes[FormIndex] == Opcode &&
          "Couldn't find FMA3 opcode!");
   return I;

--- a/lib/Target/X86/X86InstrFoldTables.cpp
+++ b/lib/Target/X86/X86InstrFoldTables.cpp
@@ -5288,7 +5288,9 @@ lookupFoldTableImpl(ArrayRef<X86MemoryFoldTableEntry> Table, unsigned RegOp) {
   }
 #endif
 
-  const X86MemoryFoldTableEntry *Data = llvm::lower_bound(Table, RegOp);
+  const X86MemoryFoldTableEntry *Data = std::lower_bound(Table.begin(),
+                                                         Table.end(),
+                                                         RegOp);
   if (Data != Table.end() && Data->KeyOp == RegOp &&
       !(Data->Flags & TB_NO_FORWARD))
     return Data;
@@ -5375,7 +5377,7 @@ static ManagedStatic<X86MemUnfoldTable> MemUnfoldTable;
 const X86MemoryFoldTableEntry *
 llvm::lookupUnfoldTable(unsigned MemOp) {
   auto &Table = MemUnfoldTable->Table;
-  auto I = llvm::lower_bound(Table, MemOp);
+  auto I = std::lower_bound(Table.begin(), Table.end(), MemOp);
   if (I != Table.end() && I->KeyOp == MemOp)
     return &*I;
   return nullptr;

--- a/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -53,7 +53,7 @@ public:
   }
 
   size_t blockToIndex(BasicBlock *BB) const {
-    auto *I = llvm::lower_bound(V, BB);
+    auto *I = std::lower_bound(V.begin(), V.end(), BB);
     assert(I != V.end() && *I == BB && "BasicBlockNumberng: Unknown block");
     return I - V.begin();
   }

--- a/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/lib/Transforms/Scalar/JumpThreading.cpp
@@ -1480,7 +1480,8 @@ bool JumpThreadingPass::SimplifyPartiallyRedundantLoad(LoadInst *LoadI) {
   for (pred_iterator PI = PB; PI != PE; ++PI) {
     BasicBlock *P = *PI;
     AvailablePredsTy::iterator I =
-        llvm::lower_bound(AvailablePreds, std::make_pair(P, (Value *)nullptr));
+      std::lower_bound(AvailablePreds.begin(), AvailablePreds.end(),
+                       std::make_pair(P, (Value*)nullptr));
 
     assert(I != AvailablePreds.end() && I->first == P &&
            "Didn't find entry for predecessor!");

--- a/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -278,8 +278,8 @@ void MemsetRanges::addRange(int64_t Start, int64_t Size, Value *Ptr,
                             unsigned Alignment, Instruction *Inst) {
   int64_t End = Start+Size;
 
-  range_iterator I = partition_point(
-      Ranges, [=](const MemsetRange &O) { return O.End < Start; });
+  range_iterator I = std::lower_bound(Ranges.begin(), Ranges.end(), Start,
+    [](const MemsetRange &LHS, int64_t RHS) { return LHS.End < RHS; });
 
   // We now know that I == E, in which case we didn't find anything to merge
   // with, or that Start <= I->End.  If End < I->Start or I == E, then we need

--- a/lib/Transforms/Scalar/Reassociate.cpp
+++ b/lib/Transforms/Scalar/Reassociate.cpp
@@ -1820,7 +1820,7 @@ Value *ReassociatePass::OptimizeMul(BinaryOperator *I,
     return V;
 
   ValueEntry NewEntry = ValueEntry(getRank(V), V);
-  Ops.insert(llvm::lower_bound(Ops, NewEntry), NewEntry);
+  Ops.insert(std::lower_bound(Ops.begin(), Ops.end(), NewEntry), NewEntry);
   return nullptr;
 }
 

--- a/test/CodeGen/ARM/inlineasm-switch-mode.ll
+++ b/test/CodeGen/ARM/inlineasm-switch-mode.ll
@@ -1,4 +1,7 @@
-;RUN: llc -mtriple=thumbv7-linux-gnueabi < %s | llvm-mc -triple=thumbv7-linux-gnueabi -filetype=obj | llvm-objdump -d - | FileCheck %s
+;RUN: llc -mtriple=thumbv7-linux-gnueabi < %s | llvm-mc -triple=thumbv7-linux-gnueabi -filetype=obj > %t
+; Two pass decoding needed because llvm-objdump does not respect mapping symbols
+;RUN: llvm-objdump -triple=armv7   -d %t | FileCheck %s --check-prefix=ARM
+;RUN: llvm-objdump -triple=thumbv7 -d %t | FileCheck %s --check-prefix=THUMB
 
 define hidden i32 @bah(i8* %start) #0 align 2 {
   %1 = ptrtoint i8* %start to i32
@@ -7,7 +10,13 @@ define hidden i32 @bah(i8* %start) #0 align 2 {
   ret i32 %3
 }
 
-; CHECK: $a{{.*}}:
-; CHECK-NEXT: 04 70 2d e5     str     r7, [sp, #-4]!
-; CHECK: $t{{.*}}:
-; CHECK-NEXT: 48 1c   adds    r0, r1, #1
+; ARM: $a
+; ARM-NEXT: 04 70 2d e5     str     r7, [sp, #-4]!
+; ARM: $t
+; ARM-NEXT: 48 1c
+
+; THUMB: $a{{.*}}:
+; THUMB-NEXT: 04 70
+; THUMB-NEXT: 2d e5
+; THUMB: $t{{.*}}:
+; THUMB-NEXT: 48 1c   adds    r0, r1, #1

--- a/test/CodeGen/WebAssembly/target-features-tls.ll
+++ b/test/CodeGen/WebAssembly/target-features-tls.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mattr=-bulk-memory | FileCheck %s --check-prefixes NO-BULK-MEM
-; RUN: llc < %s -mattr=+bulk-memory | FileCheck %s --check-prefixes BULK-MEM
+; RUN: llc < %s -mattr=-atomics | FileCheck %s --check-prefixes CHECK,NO-ATOMICS
+; RUN: llc < %s -mattr=+atomics | FileCheck %s --check-prefixes CHECK,ATOMICS
 
 ; Test that the target features section contains -atomics or +atomics
 ; for modules that have thread local storage in their source.
@@ -9,18 +9,18 @@ target triple = "wasm32-unknown-unknown"
 
 @foo = internal thread_local global i32 0
 
-; -bulk-memory
-; NO-BULK-MEM-LABEL: .custom_section.target_features,"",@
-; NO-BULK-MEM-NEXT: .int8 1
-; NO-BULK-MEM-NEXT: .int8 45
-; NO-BULK-MEM-NEXT: .int8 7
-; NO-BULK-MEM-NEXT: .ascii "atomics"
-; NO-BULK-MEM-NEXT: .bss.foo,"",@
+; CHECK-LABEL: .custom_section.target_features,"",@
 
-; +bulk-memory
-; BULK-MEM-LABEL: .custom_section.target_features,"",@
-; BULK-MEM-NEXT: .int8 1
-; BULK-MEM-NEXT: .int8 43
-; BULK-MEM-NEXT: .int8 11
-; BULK-MEM-NEXT: .ascii "bulk-memory"
-; BULK-MEM-NEXT: .tbss.foo,"",@
+; -atomics
+; NO-ATOMICS-NEXT: .int8 1
+; NO-ATOMICS-NEXT: .int8 45
+; NO-ATOMICS-NEXT: .int8 7
+; NO-ATOMICS-NEXT: .ascii "atomics"
+; NO-ATOMICS-NEXT: .bss.foo,"",@
+
+; +atomics
+; ATOMICS-NEXT: .int8 1
+; ATOMICS-NEXT: .int8 43
+; ATOMICS-NEXT: .int8 7
+; ATOMICS-NEXT: .ascii "atomics"
+; ATOMICS-NEXT: .tbss.foo,"",@

--- a/test/CodeGen/WebAssembly/tls.ll
+++ b/test/CodeGen/WebAssembly/tls.ll
@@ -1,82 +1,17 @@
-; RUN: llc < %s -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -mattr=+bulk-memory | FileCheck %s --check-prefixes=CHECK,TLS
-; RUN: llc < %s -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -mattr=+bulk-memory -fast-isel | FileCheck %s --check-prefixes=CHECK,TLS
-; RUN: llc < %s -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -mattr=-bulk-memory | FileCheck %s --check-prefixes=CHECK,NO-TLS
+; RUN: llc < %s -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck --check-prefix=SINGLE %s
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-unknown"
 
-; CHECK-LABEL: address_of_tls:
-; CHECK-NEXT: .functype  address_of_tls () -> (i32)
+; SINGLE-LABEL: address_of_tls:
 define i32 @address_of_tls() {
-  ; TLS-DAG: global.get __tls_base
-  ; TLS-DAG: i32.const tls
-  ; TLS-NEXT: i32.add
-  ; TLS-NEXT: return
-
-  ; NO-TLS-NEXT: i32.const tls
-  ; NO-TLS-NEXT: return
+  ; SINGLE: i32.const $push0=, tls
+  ; SINGLE-NEXT: return $pop0
   ret i32 ptrtoint(i32* @tls to i32)
 }
 
-; CHECK-LABEL: ptr_to_tls:
-; CHECK-NEXT: .functype ptr_to_tls () -> (i32)
-define i32* @ptr_to_tls() {
-  ; TLS-DAG: global.get __tls_base
-  ; TLS-DAG: i32.const tls
-  ; TLS-NEXT: i32.add
-  ; TLS-NEXT: return
-
-  ; NO-TLS-NEXT: i32.const tls
-  ; NO-TLS-NEXT: return
-  ret i32* @tls
-}
-
-; CHECK-LABEL: tls_load:
-; CHECK-NEXT: .functype tls_load () -> (i32)
-define i32 @tls_load() {
-  ; TLS-DAG: global.get __tls_base
-  ; TLS-DAG: i32.const tls
-  ; TLS-NEXT: i32.add
-  ; TLS-NEXT: i32.load 0
-  ; TLS-NEXT: return
-
-  ; NO-TLS-NEXT: i32.const 0
-  ; NO-TLS-NEXT: i32.load tls
-  ; NO-TLS-NEXT: return
-  %tmp = load i32, i32* @tls, align 4
-  ret i32 %tmp
-}
-
-; CHECK-LABEL: tls_store:
-; CHECK-NEXT: .functype tls_store (i32) -> ()
-define void @tls_store(i32 %x) {
-  ; TLS-DAG: global.get __tls_base
-  ; TLS-DAG: i32.const tls
-  ; TLS-NEXT: i32.add
-  ; TLS-NEXT: i32.store 0
-  ; TLS-NEXT: return
-
-  ; NO-TLS-NEXT: i32.const 0
-  ; NO-TLS-NEXT: i32.store tls
-  ; NO-TLS-NEXT: return
-  store i32 %x, i32* @tls, align 4
-  ret void
-}
-
-; CHECK-LABEL: tls_size:
-; CHECK-NEXT: .functype tls_size () -> (i32)
-define i32 @tls_size() {
-; CHECK-NEXT: global.get __tls_size
-; CHECK-NEXT: return
-  %1 = call i32 @llvm.wasm.tls.size.i32()
-  ret i32 %1
-}
-
-; CHECK: .type tls,@object
-; TLS-NEXT: .section .tbss.tls,"",@
-; NO-TLS-NEXT: .section .bss.tls,"",@
-; CHECK-NEXT: .p2align 2
-; CHECK-NEXT: tls:
-; CHECK-NEXT: .int32 0
-@tls = internal thread_local(localexec) global i32 0
-
-declare i32 @llvm.wasm.tls.size.i32()
+; SINGLE: .type	tls,@object
+; SINGLE-NEXT: .section	.bss.tls,"",@
+; SINGLE-NEXT: .p2align 2
+; SINGLE-NEXT: tls:
+; SINGLE-NEXT: .int32 0
+@tls = internal thread_local global i32 0

--- a/test/tools/llvm-objdump/ARM/v7r-subfeatures.s
+++ b/test/tools/llvm-objdump/ARM/v7r-subfeatures.s
@@ -1,6 +1,5 @@
-@ RUN: llvm-mc < %s -triple armv7r -mattr=+hwdiv-arm -filetype=obj | llvm-objdump -d - | FileCheck %s
-@ v7r implies Thumb hwdiv, but ARM hwdiv is optional
-@ FIXME: Does that imply we should actually refuse to disassemble it?
+@ RUN: llvm-mc < %s -triple armv7r -mattr=+hwdiv-arm -filetype=obj | llvm-objdump -triple=thumb -d - | FileCheck %s
+@ RUN: llvm-mc < %s -triple armv7r -mattr=+hwdiv-arm -filetype=obj | llvm-objdump -triple=arm -d - | FileCheck %s --check-prefix=CHECK-ARM
 
 .eabi_attribute Tag_CPU_arch, 10 // v7
 .eabi_attribute Tag_CPU_arch_profile, 0x52 // 'R' profile
@@ -10,7 +9,8 @@ div_arm:
   udiv r0, r1, r2
 
 @CHECK-LABEL: div_arm
-@CHECK: 11 f2 30 e7 <unknown>
+@CHECK-NOT: udiv r0, r1, r2
+@CHECK-ARM-NOT: udiv r0, r1, r2
 
 .thumb
 div_thumb:

--- a/tools/dsymutil/DwarfLinker.cpp
+++ b/tools/dsymutil/DwarfLinker.cpp
@@ -1766,16 +1766,18 @@ static void insertLineSequence(std::vector<DWARFDebugLine::Row> &Seq,
     return;
   }
 
-  object::SectionedAddress Front = Seq.front().Address;
-  auto InsertPoint = partition_point(
-      Rows, [=](const DWARFDebugLine::Row &O) { return O.Address < Front; });
+  auto InsertPoint = std::lower_bound(
+      Rows.begin(), Rows.end(), Seq.front(),
+      [](const DWARFDebugLine::Row &LHS, const DWARFDebugLine::Row &RHS) {
+        return LHS.Address < RHS.Address;
+      });
 
   // FIXME: this only removes the unneeded end_sequence if the
   // sequences have been inserted in order. Using a global sort like
   // described in patchLineTableForUnit() and delaying the end_sequene
   // elimination to emitLineTableForUnit() we can get rid of all of them.
-  if (InsertPoint != Rows.end() && InsertPoint->Address == Front &&
-      InsertPoint->EndSequence) {
+  if (InsertPoint != Rows.end() &&
+      InsertPoint->Address == Seq.front().Address && InsertPoint->EndSequence) {
     *InsertPoint = Seq.front();
     Rows.insert(InsertPoint + 1, Seq.begin() + 1, Seq.end());
   } else {

--- a/tools/llvm-xray/xray-stacks.cpp
+++ b/tools/llvm-xray/xray-stacks.cpp
@@ -633,8 +633,10 @@ public:
                               Top->ExtraData.TerminalDurations.end(), 0uLL);
           {
             auto E = std::make_pair(Top, TopSum);
-            TopStacksBySum.insert(
-                llvm::lower_bound(TopStacksBySum, E, greater_second), E);
+            TopStacksBySum.insert(std::lower_bound(TopStacksBySum.begin(),
+                                                   TopStacksBySum.end(), E,
+                                                   greater_second),
+                                  E);
             if (TopStacksBySum.size() == 11)
               TopStacksBySum.pop_back();
           }

--- a/unittests/ADT/STLExtrasTest.cpp
+++ b/unittests/ADT/STLExtrasTest.cpp
@@ -469,14 +469,25 @@ TEST(STLExtrasTest, to_address) {
   EXPECT_EQ(V1, to_address(V3));
 }
 
-TEST(STLExtrasTest, partition_point) {
+TEST(STLExtrasTest, bsearch) {
+  // Integer version.
+  EXPECT_EQ(7u, bsearch(5, 10, [](unsigned X) { return X >= 7; }));
+  EXPECT_EQ(5u, bsearch(5, 10, [](unsigned X) { return X >= 1; }));
+  EXPECT_EQ(10u, bsearch(5, 10, [](unsigned X) { return X >= 50; }));
+
+  // Iterator version.
   std::vector<int> V = {1, 3, 5, 7, 9};
+  EXPECT_EQ(V.begin() + 3,
+            bsearch(V.begin(), V.end(), [](unsigned X) { return X >= 7; }));
+  EXPECT_EQ(V.begin(),
+            bsearch(V.begin(), V.end(), [](unsigned X) { return X >= 1; }));
+  EXPECT_EQ(V.end(),
+            bsearch(V.begin(), V.end(), [](unsigned X) { return X >= 50; }));
 
   // Range version.
-  EXPECT_EQ(V.begin() + 3,
-            partition_point(V, [](unsigned X) { return X < 7; }));
-  EXPECT_EQ(V.begin(), partition_point(V, [](unsigned X) { return X < 1; }));
-  EXPECT_EQ(V.end(), partition_point(V, [](unsigned X) { return X < 50; }));
+  EXPECT_EQ(V.begin() + 3, bsearch(V, [](unsigned X) { return X >= 7; }));
+  EXPECT_EQ(V.begin(), bsearch(V, [](unsigned X) { return X >= 1; }));
+  EXPECT_EQ(V.end(), bsearch(V, [](unsigned X) { return X >= 50; }));
 }
 
 } // namespace


### PR DESCRIPTION
Reverts apple/swift-llvm#172

Going to revert PR#172 because it's causing build failure: 

```
/tmp/llvm/tools/clang/lib/Tooling/Syntax/Tokens.cpp:129:19: error: no member named 'bsearch' in namespace 'llvm'
   auto It = llvm::bsearch(File.Mappings, [&](const Mapping &M) {
             ~~~~~~^
 /tmp/llvm/tools/clang/lib/Tooling/Syntax/Tokens.cpp:214:18: error: no member named 'bsearch' in namespace 'llvm'
   auto M = llvm::bsearch(File.Mappings, [&](const Mapping &M) {
            ~~~~~~^
 2 errors generated.
```

Might be related to this commit https://github.com/apple/swift-llvm/commit/135e0fd8b64ed85692768d79e80dc937fafc4562

We might be able to resolve this by cherry-pick this commit into clang:
https://github.com/apple/swift-clang/commit/f888b24b827087a9d8522c269a0de5c88c6bea0d